### PR TITLE
Add conf path

### DIFF
--- a/src/fmu/sumo/sim2sumo/sim2sumo.py
+++ b/src/fmu/sumo/sim2sumo/sim2sumo.py
@@ -270,10 +270,10 @@ def export_with_config(config_path):
 def upload(
     upload_folder,
     suffixes,
-    conf_path="./fmuconfig/output/global_variables.yml",
     env="prod",
     threads=5,
     start_del="real",
+    config_path="./fmuconfig/output/global_variables.yml",
 ):
     """Upload to sumo
 
@@ -295,11 +295,11 @@ def upload(
             logger.info("Upload folder %s", upload_search)
             sumo_upload_main(
                 case_path,
-                conf_path,
                 upload_search,
                 env,
                 case_meta_path,
                 threads,
+                config_path,
             )
             logger.debug("Uploaded")
     except TypeError:
@@ -399,7 +399,7 @@ def upload_with_config(config_path, env="prod"):
     logger.debug("config: %s: ", config_path)
     logger.debug("Sumo env: %s: ", env)
     upload_folder, suffixes = export_with_config(config_path)
-    upload(upload_folder, suffixes, config_path, env)
+    upload(upload_folder, suffixes, env, config_path=config_path)
 
 
 def main():

--- a/src/fmu/sumo/sim2sumo/sim2sumo.py
+++ b/src/fmu/sumo/sim2sumo/sim2sumo.py
@@ -267,7 +267,14 @@ def export_with_config(config_path):
     return export_folder, suffixes
 
 
-def upload(upload_folder, suffixes, env="prod", threads=5, start_del="real"):
+def upload(
+    upload_folder,
+    suffixes,
+    conf_path="./fmuconfig/output/global_variables.yml",
+    env="prod",
+    threads=5,
+    start_del="real",
+):
     """Upload to sumo
 
     Args:
@@ -288,6 +295,7 @@ def upload(upload_folder, suffixes, env="prod", threads=5, start_del="real"):
             logger.info("Upload folder %s", upload_search)
             sumo_upload_main(
                 case_path,
+                conf_path,
                 upload_search,
                 env,
                 case_meta_path,
@@ -391,7 +399,7 @@ def upload_with_config(config_path, env="prod"):
     logger.debug("config: %s: ", config_path)
     logger.debug("Sumo env: %s: ", env)
     upload_folder, suffixes = export_with_config(config_path)
-    upload(upload_folder, suffixes, env)
+    upload(upload_folder, suffixes, config_path, env)
 
 
 def main():

--- a/src/fmu/sumo/sim2sumo/sim2sumo.py
+++ b/src/fmu/sumo/sim2sumo/sim2sumo.py
@@ -43,7 +43,9 @@ def give_name(datafile_path: str) -> str:
         str: derived name
     """
     datafile_path_posix = Path(datafile_path)
-    base_name = datafile_path_posix.name.replace(datafile_path_posix.suffix, "")
+    base_name = datafile_path_posix.name.replace(
+        datafile_path_posix.suffix, ""
+    )
     while base_name[-1].isdigit() or base_name.endswith("-"):
         base_name = base_name[:-1]
     return base_name
@@ -188,7 +190,9 @@ def read_config(config):
     try:
         simconfig = config["sim2sumo"]
     except KeyError:
-        logger.warning("No specification in config, will use defaults %s", defaults)
+        logger.warning(
+            "No specification in config, will use defaults %s", defaults
+        )
         simconfig = defaults
     if isinstance(simconfig, bool):
         simconfig = defaults
@@ -284,6 +288,7 @@ def upload(
         threads (int, optional): Threads to use in upload. Defaults to 5.
     """
     logger = logging.getLogger(__file__ + ".upload")
+    print(f"CONFIG_PATH: {config_path}")
     try:
         case_path = Path(re.sub(rf"\/{start_del}.*", "", upload_folder))
         logger.info("Case to upload from %s", case_path)

--- a/src/fmu/sumo/sim2sumo/sim2sumo.py
+++ b/src/fmu/sumo/sim2sumo/sim2sumo.py
@@ -45,7 +45,9 @@ def give_name(datafile_path: str) -> str:
         str: derived name
     """
     datafile_path_posix = Path(datafile_path)
-    base_name = datafile_path_posix.name.replace(datafile_path_posix.suffix, "")
+    base_name = datafile_path_posix.name.replace(
+        datafile_path_posix.suffix, ""
+    )
     while base_name[-1].isdigit() or base_name.endswith("-"):
         base_name = base_name[:-1]
     return base_name
@@ -175,7 +177,9 @@ def read_config(config, datafile=None, datatype=None):
     try:
         simconfig = config["sim2sumo"]
     except KeyError:
-        logger.warning("No specification in config, will use defaults %s", defaults)
+        logger.warning(
+            "No specification in config, will use defaults %s", defaults
+        )
         simconfig = defaults
     if isinstance(simconfig, bool):
         simconfig = defaults
@@ -280,7 +284,6 @@ def upload(
         threads (int, optional): Threads to use in upload. Defaults to 5.
     """
     logger = logging.getLogger(__file__ + ".upload")
-    print(f"CONFIG_PATH: {config_path}")
     try:
         case_path = Path(re.sub(rf"\/{start_del}.*", "", upload_folder))
         logger.info("Case to upload from %s", case_path)
@@ -409,7 +412,9 @@ def upload_with_config(config_path, datafile, datatype, env):
     logger.debug("config: %s: ", config_path)
     logger.debug("Sumo env: %s: ", env)
 
-    upload_folder, suffixes = export_with_config(config_path, datafile, datatype)
+    upload_folder, suffixes = export_with_config(
+        config_path, datafile, datatype
+    )
     upload(upload_folder, suffixes, env, config_path=config_path)
 
 
@@ -420,7 +425,9 @@ def main():
     try:
         print(give_help(args.help_on))
     except AttributeError:
-        upload_with_config(args.config_path, args.datafile, args.datatype, args.env)
+        upload_with_config(
+            args.config_path, args.datafile, args.datatype, args.env
+        )
 
 
 if __name__ == "__main__":

--- a/src/fmu/sumo/sim2sumo/sim2sumo.py
+++ b/src/fmu/sumo/sim2sumo/sim2sumo.py
@@ -273,7 +273,7 @@ def upload(
     env="prod",
     threads=5,
     start_del="real",
-    config_path="./fmuconfig/output/global_variables.yml",
+    config_path="fmuconfig/output/global_variables.yml",
 ):
     """Upload to sumo
 


### PR DESCRIPTION
Pass `config_path` to `sumo_upload`. `sumo_upload` will attempt to upload parameters.txt which needs the config to produce metadata using `fmu-dataio`. This operation is currently failing if the asset has their global variables somewhere other than `fmuconfig/output/global_variables.yml`. This PR is dependent on a PR in the uploader: https://github.com/equinor/fmu-sumo-uploader/pull/14