### PR TITLE
bugfix:find_datafiles

### DIFF
--- a/src/fmu/sumo/sim2sumo/sim2sumo.py
+++ b/src/fmu/sumo/sim2sumo/sim2sumo.py
@@ -250,10 +250,7 @@ def is_datafile(results: PosixPath) -> bool:
         bool: true if correct suffix
     """
     valid = [".afi", ".DATA", ".in"]
-    check = False
-    if results.suffix in valid:
-        check = True
-    return check
+    return results.suffix in valid
 
 
 def find_datafiles(seedpoint, simconfig):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -17,11 +17,12 @@ from fmu.sumo.sim2sumo._special_treatments import (
 
 REEK_ROOT = Path(__file__).parent / "data/reek"
 REAL_PATH = "realization-0/iter-0/"
-REEK_REAL = REEK_ROOT / REAL_PATH
+REEK_REAL0 = REEK_ROOT / "realization-0/iter-0/"
+REEK_REAL1 = REEK_ROOT / "realization-1/iter-0/"
 REEK_BASE = "2_R001_REEK"
-REEK_ECL_MODEL = REEK_REAL / "eclipse/model/"
+REEK_ECL_MODEL = REEK_REAL0 / "eclipse/model/"
 REEK_DATA_FILE = REEK_ECL_MODEL / f"{REEK_BASE}-0.DATA"
-CONFIG_OUT_PATH = REEK_REAL / "fmuconfig/output/"
+CONFIG_OUT_PATH = REEK_REAL0 / "fmuconfig/output/"
 CONFIG_PATH = CONFIG_OUT_PATH / "global_variables.yml"
 
 
@@ -38,13 +39,14 @@ def test_fix_suffix():
     assert corrected_path.endswith(".DATA"), f"Didn't correct {corrected_path}"
 
 
-def test_find_datafiles_reek():
-    os.chdir(REEK_REAL)
+@pytest.mark.parametrize("real,nrdfiles", [(REEK_REAL0, 5), (REEK_REAL1, 1)])
+def test_find_datafiles_reek(real, nrdfiles):
+    os.chdir(real)
     datafiles = sim2sumo.find_datafiles(None, {})
     expected_tools = ["eclipse", "opm", "ix", "pflotran"]
     assert (
-        len(datafiles) == 5
-    ), f"Haven't found all 5 files only {len(datafiles)} ({datafiles})"
+        len(datafiles) == nrdfiles
+    ), f"Haven't found all {nrdfiles} files only {len(datafiles)} ({datafiles})"
     for datafile in datafiles:
         found_path = datafile
         parent = found_path.parent.parent.name
@@ -200,7 +202,7 @@ def _assert_right_len(checks, key, to_messure, name):
 @pytest.mark.parametrize("config_path", CONFIG_OUT_PATH.glob("*.yml"))
 def test_read_config(config_path):
     """Test reading of config file via read_config function"""
-    os.chdir(REEK_REAL)
+    os.chdir(REEK_REAL0)
     LOGGER.info(config_path)
     config = sim2sumo.yaml_load(config_path)
     assert isinstance(config, (dict, bool))


### PR DESCRIPTION
Fix  lack of export with fmudataio when running Drogon. 
When creating this branch the following stderror could be observed when running drogon in bleeding:

`Error reading summary instance, returning empty dataframe
Trace: [Errno 2] No such file or directory: 'ix/model/.RFT',
No results produced
Error reading summary instance, returning empty dataframe
Trace: [Errno 2] No such file or directory: 'opm/model/.RFT',
No results produced
Error reading summary instance, returning empty dataframe
Trace: [Errno 2] No such file or directory: 'pflotran/model.RFT',
No results produced
WARNING:fmu.sumo.uploader.scripts.sumo_upload:Problem related to Sumo upload: case metadata not found: share/metadata/fmu_case.yml <class 'OSError'>
WARNING:fmu.sumo.uploader.scripts.sumo_upload:Problem related to Sumo upload: case metadata not found: share/metadata/fmu_case.yml <class 'OSError'>`
This could be reproduced in tests.
 See test: _test_find_datafiles_reek_ in file _test_functions.py_
The PR fixes these tests.

Manually running this code on a drogon case: 
* Log into RGS node
* cd to _/scratch/sumo/rowh/oldDrogon_komodoBleeding/realization-0/iter-0/share/results/tables_ (_EDIT peesv: Should be on realization root, not in share/results/tables_)
* run `sim2sumo execute --config_path fmuconfig/output/global_variables.yml` (_EDIT peesv: Should have --env dev appended since case is in `dev`_)

So far export of results are being done (which they weren't before), but fmu dataio fails.
Merging this pull request will remove most of the errors, but **Not** what is related to the uploading.
The theory goes that this is because something is fishy with fmu-dataio in bleeding


Trying manual upload of files exported with no relation to sim2sumo also fails
e.g `sumo_upload /scratch/sumo/rowh/oldDrogon_komodoBleeding /scratch/sumo/rowh/oldDrogon_komodoBleeding/realization-0/iter-0/share/results/tables/model--summary.arrow dev `