### PR TITLE
Remove suffix before calling res2df

### DIFF
--- a/src/fmu/sumo/sim2sumo/_special_treatments.py
+++ b/src/fmu/sumo/sim2sumo/_special_treatments.py
@@ -210,7 +210,8 @@ def vfp_to_arrow_dict(datafile, options):
         tuple: vfp keyword, then dictionary with key: table_name, value: table
     """
     logger = logging.getLogger(__file__ + ".vfp_to_arrow_dict")
-    resdatafiles = res2df.ResdataFiles(datafile)
+    filepath_no_suffix = Path(datafile).with_suffix("")
+    resdatafiles = res2df.ResdataFiles(filepath_no_suffix)
     vfp_dict = {}
     keyword = options.get("keyword", "VFPPROD")
     logger.debug("keyword is %s", keyword)

--- a/src/fmu/sumo/sim2sumo/tables.py
+++ b/src/fmu/sumo/sim2sumo/tables.py
@@ -6,6 +6,7 @@
 """
 
 import logging
+from pathlib import Path
 import sys
 from typing import Union
 
@@ -169,8 +170,9 @@ def get_table(
                 extract_df.__name__,
                 submod,
             )
+            datafile_path_no_suffix = Path(datafile_path).with_suffix("")
             output = extract_df(
-                res2df.ResdataFiles(datafile_path),
+                res2df.ResdataFiles(datafile_path_no_suffix),
                 **kwargs,
             )
             if submod == "rft":


### PR DESCRIPTION
Remove suffix from filepath before calling `res2df.ResdataFiles`.

`ResdataFiles` warns if file does not have `.DATA` suffix, but still works if file does not have it.
So res2df seems to work on files if they don't have suffix. However, if there **is** a suffix that is **not** `.DATA` then it will fail since res2df only ignores `.DATA` specifically.

So if we remove the suffix before passing filepath to res2df it should work (given that the path points to a valid file), without needing the correct suffix.
This solves an issue with files from "Intersect" with suffix `.afi`