### PR TITLE
Fix datafiles

### DIFF
--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -215,7 +215,7 @@ def create_config_dict(config, datafile=None, datatype=None):
         datafiles_paths = find_datafiles(datafile)
         for datafile_path in datafiles_paths:
             sim2sumoconfig[datafile_path] = {}
-            for submod in datatype or []:
+            for submod in submods or []:
                 options = simconfig.get("options", {"arrow": True})
                 sim2sumoconfig[datafile_path][submod] = filter_options(submod, options)
             sim2sumoconfig[datafile_path]["grid3d"] = grid3d

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -111,8 +111,9 @@ def find_datafiles(seedpoint=None):
     elif isinstance(seedpoint, list):
         # If seedpoint is a list, ensure all elements are strings or Path objects
         seedpoint = [Path(sp) for sp in seedpoint]
-    else:
+    elif seedpoint:
         seedpoint = [seedpoint]
+    
     if seedpoint:
         for sp in seedpoint:
             full_path = (

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -234,7 +234,7 @@ class Dispatcher:
     ):
         self._logger = logging.getLogger(__name__ + ".Dispatcher")
         self._limit_percent = 0.5
-        self._parentid = get_case_uuid(Path.cwd(), parent_level=1)
+        self._parentid = get_case_uuid(datafile.resolve())
         self._conn = SumoConnection(env=env, token=token)
         self._env = env
         self._mem_limit = psutil.virtual_memory().available * self._limit_percent

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -305,12 +305,14 @@ def find_datafiles_no_seedpoint():
     logger = logging.getLogger(__file__ + ".find_datafiles_no_seedpoint")
     cwd = Path().cwd()
     logger.info("Looking for files in %s", cwd)
-    valid_filetypes = [".afi", ".DATA", ".in"]
-    datafiles = list(
-        filter(
-            lambda file: file.suffix in valid_filetypes, cwd.glob("*/*/*.*")
-        )
-    )
+    valid_filetypes = [".DATA", ".afi", ".in"]
+    datafiles = []
+    for filetypes in valid_filetypes:
+        datafiles.extend(list(
+            filter(
+                lambda file: (file.suffix in valid_filetypes and file.with_suffix('').stem not in [datafile.with_suffix('').stem for datafile in datafiles]), cwd.glob(f"*/*/*{filetypes}")
+            )
+        ))
     logger.debug("Found the following datafiles %s", datafiles)
     return datafiles
 

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -119,9 +119,13 @@ def find_datafiles(seedpoint=None):
             full_path = (
                 cwd / sp if not sp.is_absolute() else sp
             )  # Make the path absolute
-            if full_path.is_file() and full_path.suffix in valid_filetypes:
-                # Add the file if it has a valid filetype
-                datafiles.append(full_path)
+            if full_path.suffix in valid_filetypes:
+                if full_path.is_file():
+                    # Add the file if it has a valid filetype
+                    datafiles.append(full_path)
+                else:
+                    for filetype in valid_filetypes:
+                        datafiles.extend([f for f in full_path.parent.rglob(f"{full_path.name}*{filetype}")])
             else:
                 for filetype in valid_filetypes:
                     if not full_path.is_dir():

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -169,7 +169,7 @@ def create_config_dict(config, datafile=None, datatype=None):
     grid3d = simconfig.get("grid3d", False)
 
     # Use the provided datafile or datatype if given, otherwise use simconfig
-    datafile = datafile if datafile is not None else simconfig.get("datafile", {})
+    datafile = datafile if datafile is not None else simconfig.get("datafile", None)
     datatype = datatype if datatype is not None else simconfig.get("datatypes", None)
 
     if datatype is None:

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -124,8 +124,7 @@ def find_datafiles(seedpoint=None):
                     # Add the file if it has a valid filetype
                     datafiles.append(full_path)
                 else:
-                    for filetype in valid_filetypes:
-                        datafiles.extend([f for f in full_path.parent.rglob(f"{full_path.name}*{filetype}")])
+                    datafiles.extend([f for f in full_path.parent.rglob(f"{full_path.name}")])
             else:
                 for filetype in valid_filetypes:
                     if not full_path.is_dir():

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -178,6 +178,8 @@ def create_config_dict(config, datafile=None, datatype=None):
 
         if submods == "all":
             submods = SUBMODULES
+    elif isinstance(datatype,list):
+        submods = datatype
     else:
         submods = [datatype]
 

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -80,9 +80,7 @@ def filter_options(submod, kwargs):
         for key, value in kwargs.items()
         if (key in submod_options) or key in ["arrow", "md_log_file"]
     }
-    filtered["arrow"] = kwargs.get(
-        "arrow", True
-    )  # defaulting of arrow happens here
+    filtered["arrow"] = kwargs.get("arrow", True)  # defaulting of arrow happens here
     logger.debug("After filtering options for %s: %s", submod, filtered)
     non_options = [key for key in kwargs if key not in filtered]
     if len(non_options) > 0:
@@ -114,10 +112,7 @@ def find_full_path(datafile, paths):
     try:
         return paths[data_name]
     except KeyError:
-        mess = (
-            "Datafile %s, with derived name %s, not found in %s,"
-            " have to skip"
-        )
+        mess = "Datafile %s, with derived name %s, not found in %s," " have to skip"
         logger.warning(mess, datafile, data_name, paths)
         return None
 
@@ -136,9 +131,7 @@ def find_datafile_paths():
         if name not in paths:
             paths[name] = data_path
         else:
-            logger.warning(
-                "Name %s from file %s allready used", name, data_path
-            )
+            logger.warning("Name %s from file %s allready used", name, data_path)
 
     return paths
 
@@ -181,9 +174,7 @@ def create_config_dict(config, datafile=None, datatype=None):
     return outdict
 
 
-def create_config_dict_from_list(
-    datatype, simconfig, datafiles, paths, grid3d
-):
+def create_config_dict_from_list(datatype, simconfig, datafiles, paths, grid3d):
     """Prepare dictionary from list of datafiles and simconfig
 
     Args:
@@ -256,9 +247,7 @@ def create_config_dict_from_dict(datafiles, paths, grid3d):
                     submod,
                     options,
                 )
-                outdict[datafile_path][submod] = filter_options(
-                    submod, options
-                )
+                outdict[datafile_path][submod] = filter_options(submod, options)
         except AttributeError:
             for submod in datafiles[datafile]:
                 outdict[datafile_path][submod] = {}
@@ -308,11 +297,18 @@ def find_datafiles_no_seedpoint():
     valid_filetypes = [".DATA", ".afi", ".in"]
     datafiles = []
     for filetypes in valid_filetypes:
-        datafiles.extend(list(
-            filter(
-                lambda file: (file.suffix in valid_filetypes and file.with_suffix('').stem not in [datafile.with_suffix('').stem for datafile in datafiles]), cwd.glob(f"*/*/*{filetypes}")
+        datafiles.extend(
+            list(
+                filter(
+                    lambda file: (
+                        file.suffix in valid_filetypes
+                        and file.with_suffix("").stem
+                        not in [datafile.with_suffix("").stem for datafile in datafiles]
+                    ),
+                    cwd.glob(f"*/*/*{filetypes}"),
+                )
             )
-        ))
+        )
     logger.debug("Found the following datafiles %s", datafiles)
     return datafiles
 
@@ -332,17 +328,13 @@ class Dispatcher:
         self._parentid = get_case_uuid(datafile)
         self._conn = SumoConnection(env=env, token=token)
         self._env = env
-        self._mem_limit = (
-            psutil.virtual_memory().available * self._limit_percent
-        )
+        self._mem_limit = psutil.virtual_memory().available * self._limit_percent
         self._config_path = config_path
 
         self._mem_count = 0
         self._count = 0
         self._objects = []
-        self._logger.info(
-            "Init, parent is %s, and env is %s", self.parentid, self.env
-        )
+        self._logger.info("Init, parent is %s, and env is %s", self.parentid, self.env)
 
     @property
     def parentid(self):
@@ -373,9 +365,7 @@ class Dispatcher:
             self._mem_count += file.size
             self._objects.append(file)
             self._count += 1
-            self._mem_limit = (
-                psutil.virtual_memory().available * self._limit_percent
-            )
+            self._mem_limit = psutil.virtual_memory().available * self._limit_percent
 
             self._logger.debug(
                 "Count is %s, and mem frac is %f1.1",
@@ -462,9 +452,7 @@ def generate_meta(config, datafile_path, tagname, obj, content):
     relative_parent = str(Path(datafile_path).parents[2]).replace(
         str(Path(datafile_path).parents[4]), ""
     )
-    metadata["file"] = {
-        "relative_path": f"{relative_parent}/{name}--{tagname}".lower()
-    }
+    metadata["file"] = {"relative_path": f"{relative_parent}/{name}--{tagname}".lower()}
     logger.debug("Generated metadata are:\n%s", metadata)
     return metadata
 
@@ -492,9 +480,7 @@ def convert_2_sumo_file(obj, converter, metacreator, meta_args):
     bytestring = converter(obj)
     metadata = metacreator(*meta_args)
     logger.debug("Metadata created")
-    assert isinstance(
-        metadata, dict
-    ), f"meta should be dict, but is {type(metadata)}"
+    assert isinstance(metadata, dict), f"meta should be dict, but is {type(metadata)}"
     assert isinstance(
         bytestring, bytes
     ), f"bytestring should be bytes, but is {type(bytestring)}"
@@ -521,9 +507,7 @@ def nodisk_upload(files, parent_id, config_path, env="prod", connection=None):
     if len(files) > 0:
         if connection is None:
             connection = SumoConnection(env=env)
-        status = upload_files(
-            files, parent_id, connection, config_path=config_path
-        )
+        status = upload_files(files, parent_id, connection, config_path=config_path)
         print("Status after upload: ", end="\n--------------\n")
         for state, obj_status in status.items():
             print(f"{state}: {len(obj_status)}")
@@ -543,9 +527,7 @@ def give_name(datafile_path: str) -> str:
     logger = logging.getLogger(__name__ + ".give_name")
     logger.info("Giving name from path %s", datafile_path)
     datafile_path_posix = Path(datafile_path)
-    base_name = datafile_path_posix.name.replace(
-        datafile_path_posix.suffix, ""
-    )
+    base_name = datafile_path_posix.name.replace(datafile_path_posix.suffix, "")
     while base_name[-1].isdigit() or base_name.endswith("-"):
         base_name = base_name[:-1]
     logger.info("Returning name %s", base_name)

--- a/src/fmu/sumo/sim2sumo/tables.py
+++ b/src/fmu/sumo/sim2sumo/tables.py
@@ -217,6 +217,7 @@ def upload_tables(sim2sumoconfig, config, dispatcher):
     logger = logging.getLogger(__file__ + ".upload_tables")
     logger.debug("Will upload with settings %s", sim2sumoconfig)
     for datafile_path, submod_and_options in sim2sumoconfig.items():
+        datafile_path = datafile_path.resolve()
         logger.debug("datafile: %s", datafile_path)
         upload_tables_from_simulation_run(
             datafile_path,

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -358,7 +358,7 @@ def test_convert_to_arrow():
 @pytest.mark.parametrize("real,nrdfiles", [(REEK_REAL0, 2), (REEK_REAL1, 5)])
 def test_find_datafiles_reek(real, nrdfiles):
     os.chdir(real)
-    datafiles = find_datafiles(None, None)
+    datafiles = find_datafiles(None)
     expected_tools = ["eclipse", "opm", "ix", "pflotran"]
     assert (
         len(datafiles) == nrdfiles

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -19,7 +19,6 @@ from fmu.sumo.sim2sumo.common import (
     nodisk_upload,
     Dispatcher,
     find_datefield,
-    find_datafiles_no_seedpoint,
     filter_options,
     get_case_uuid,
 )
@@ -133,10 +132,10 @@ def test_get_case_uuid(case_uuid, scratch_files, monkeypatch):
             3,
         ),
         ({"datafile": ["3_R001_REEK", "OOGRE_PF.in"]}, 2, 4),
-        ({"datafile": "3_R001_REEK"}, 1, 4),
-        ({"datafile": "3_R001_REEK.DATA"}, 1, 4),
-        ({"datafile": "OOGRE_IX.afi"}, 1, 4),
-        ({"datafile": "opm/model/OOGRE_OPM.DATA"}, 1, 4),
+        ({"datafile": ["3_R001_REEK"]}, 1, 4),
+        ({"datafile": ["3_R001_REEK-1.DATA"]}, 1, 4),
+        ({"datafile": ["OOGRE_IX.afi"]}, 1, 4),
+        ({"datafile": ["opm/model/OOGRE_OPM.DATA"]}, 1, 4),
         ({"grid3d": True}, 5, 4),
     ],
 )
@@ -359,7 +358,7 @@ def test_convert_to_arrow():
 @pytest.mark.parametrize("real,nrdfiles", [(REEK_REAL0, 2), (REEK_REAL1, 5)])
 def test_find_datafiles_reek(real, nrdfiles):
     os.chdir(real)
-    datafiles = find_datafiles(None, {})
+    datafiles = find_datafiles(None, None)
     expected_tools = ["eclipse", "opm", "ix", "pflotran"]
     assert (
         len(datafiles) == nrdfiles
@@ -373,11 +372,3 @@ def test_find_datafiles_reek(real, nrdfiles):
         if parent == "pflotran":
             correct_suff = ".in"
         assert found_path.suffix == correct_suff
-
-
-def test_find_datafiles_no_seedpoint(tmp_path):
-    real1 = tmp_path / "realone"
-    copytree(REEK_REAL1, real1)
-    os.chdir(real1)
-    files = find_datafiles_no_seedpoint()
-    assert len(files) == 5


### PR DESCRIPTION
Currently sim2sumo finds all paths to datafiles with valid filetypes `.DATA`, `.afi` and `.in`. However only the stem name are used as table name (and not the subfolders). Hence if two datafiles has same stem the random first one will be chosen, not taking into account the _seedpoint_ (or `datafile:`) given in the config file. ~This does not fix that, but it does at least prioritize the `.DATA` file over `.afi` and `.afi` over `.in` making the results consistent over an ensemble.~ This tries to fix that 😅 