### PR TITLE
Require certain ERT env variables before running

### DIFF
--- a/src/fmu/sumo/sim2sumo/main.py
+++ b/src/fmu/sumo/sim2sumo/main.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+from os import environ
 
 from .grid3d import upload_simulation_runs
 from .tables import upload_tables
@@ -64,9 +65,24 @@ def parse_args():
     return args
 
 
+# fmu-dataio needs these when creating metadata
+REQUIRED_ENV_VARS = ["_ERT_EXPERIMENT_ID", "_ERT_RUNPATH"]
+
+
 def main():
     """Main function to be called"""
     logger = logging.getLogger(__file__ + ".main")
+
+    missing = 0
+    for envVar in REQUIRED_ENV_VARS:
+        if environ.get(envVar) is None:
+            print(f"{envVar} is not set.")
+            missing += 1
+
+    if missing > 0:
+        print("Missing required environment variables. Stopping.")
+        exit()
+
     args = parse_args()
     logger.debug("Running with arguments %s", args)
     if args.help_on != "No help":

--- a/src/fmu/sumo/sim2sumo/main.py
+++ b/src/fmu/sumo/sim2sumo/main.py
@@ -66,11 +66,11 @@ def main():
     missing = 0
     for envVar in REQUIRED_ENV_VARS:
         if environ.get(envVar) is None:
-            print(f"{envVar} is not set.")
+            print(f"Required environment variable {envVar} is not set.")
             missing += 1
 
     if missing > 0:
-        print("Missing required environment variables. Stopping.")
+        print("Required ERT environment variables not found. This can happen if sim2sumo was called outside the ERT context. Stopping.")
         exit()
 
     args = parse_args()


### PR DESCRIPTION
`fmu-dataio` requires certain ERT variables to be set in order to create metadata correctly.
Add check to see if they are set, if not print error and exit.

