### PR TITLE
More refactoring

### DIFF
--- a/docs/sim2sumo.rst
+++ b/docs/sim2sumo.rst
@@ -150,37 +150,43 @@ The three relevant sections are:
 
 *datafile*:
 --------------------
-This section is for configuring where you extract results from, meaning where to look for simulation results. This section can be configured in several ways:
+This section is for configuring where you extract results from, meaning where to look for simulation results.
+This section should be a list where each item is either a file path, file stub or a folder path.
 
-1. As a path to a file, or file stub (without an extension):
-
-   .. code-block:: yaml
-
-      datafile ../../eclipse/model/DROGON
-
-
-2. As a path to a folder:
-
-   .. code-block::
-
-      datafile: ../../eclipse/model/
-
-
-3. As a list:
+1. File paths, or file stubs (without an extension):
 
    .. code-block::
 
       datafile:
-        - ../../eclipse/model
-        - ../../ix/model
-        ..
+         - ../../eclipse/model/DROGON
+         - ../../eclipse/model/DROGON-0.DATA
+
+
+2. Folder paths:
+
+   .. code-block::
+
+      datafile:
+         - ../../eclipse/model/
+
+
+You can also specify what datatypes should be extracted for each file, by adding a list of datatypes to each file path:
+
+   .. code-block::
+      datafile:
+         - ../../eclipse/model/DROGON:
+            - summary
+            - wcon
+            - faults
+         - ../../eclipse/model/DROGON-0.DATA:
+            - summary
+            - wcon
+            - faults
 
 
 datatypes:
 ----------------
-This section is for configuration of what data to extract. The section can be configured in several ways.
-
-1. As list:
+This section is for configuration of what data to extract. It should be specified as a list
 
    .. code-block::
 
@@ -190,17 +196,14 @@ This section is for configuration of what data to extract. The section can be co
         - faults
         - ..
 
-2. as string:
-
-   Here there are two options, you can use both the name of one single datatype
-   or the 'all' argument for all datatypes:
+To include all datatypes use a list with a single item "all":
 
    .. code-block::
-      :caption: extracting all available datatypes from simulation run
 
-      datatypes: all
+      datatypes:
+         - all
 
-   For datatypes available see documentation for ``res2df``
+For datatypes available see documentation for ``res2df``
 
 options:
 -------------

--- a/docs/sim2sumo.rst
+++ b/docs/sim2sumo.rst
@@ -248,14 +248,6 @@ Extracting the default datatypes with sim2sumo
 
 See also :ref:`preconditions`.
 
-Extracting rft data from specified datafile with sim2sumo
-----------------------------------------------------------------
-
-.. code-block::
-   :caption: Extracting rft
-
-   sum2sumo execute --config_path fmuconfig/output/global_variables.yml --datatype rft --datafile eclipse/model/DROGON-0.DATA
-
 
 Getting help on sim2sumo from the command line
 =================================================

--- a/src/fmu/sumo/sim2sumo/_special_treatments.py
+++ b/src/fmu/sumo/sim2sumo/_special_treatments.py
@@ -21,8 +21,6 @@ def convert_to_arrow(frame):
     Returns:
         pa.Table: the converted dataframe
     """
-    logger = logging.getLogger(__file__ + ".convert_to_arrow")
-    logger.debug("!!!!Using convert to arrow!!!")
     standard = {"DATE": pa.timestamp("ms")}
     if "DATE" in frame.columns:
         frame["DATE"] = pd.to_datetime(frame["DATE"])
@@ -34,7 +32,6 @@ def convert_to_arrow(frame):
             scheme.append(
                 (column_name, standard.get(column_name, pa.float32()))
             )
-    logger.debug(scheme)
     table = pa.Table.from_pandas(frame, schema=pa.schema(scheme))
     return table
 
@@ -122,7 +119,6 @@ def find_md_log(submod, options):
     Returns:
         str|None: whatever contained in md_log_file
     """
-    logger = logging.getLogger(__file__ + ".find_md_log")
     if submod != "rft":
         return None
     # Special treatment of argument md_log_file
@@ -130,7 +126,7 @@ def find_md_log(submod, options):
     try:
         del options["md_log_file"]
     except KeyError:
-        logger.debug("No md log provided")
+        pass  # No md log provided
 
     return md_log_file
 
@@ -206,9 +202,6 @@ def add_md_to_rft(rft_table, md_file_path):
     Returns:
         pd.Dataframe: the merged results
     """
-    logger = logging.getLogger(__file__ + ".add_md_to_rft")
-    logger.debug("Head of rft table prior to merge:\n %s", rft_table.head())
-
     try:
         md_table = pd.read_csv(md_file_path)
     except FileNotFoundError as fnfe:
@@ -222,19 +215,7 @@ def add_md_to_rft(rft_table, md_file_path):
     md_table[xtgeo_index_names] += 1
     md_table[xtgeo_index_names] = md_table[xtgeo_index_names].astype(int)
     xtgeo_to_rft_names = dict(zip(xtgeo_index_names, rft_index_names))
-    logger.debug(
-        "Datatypes, md_table: %s, rft_table: %s",
-        md_table[xtgeo_index_names].dtypes,
-        rft_table[rft_index_names].dtypes,
-    )
-    logger.debug(
-        "Shapes before merge rft: %s, md: %s", rft_table.shape, md_table.shape
-    )
     md_table.rename(xtgeo_to_rft_names, axis=1, inplace=True)
-    logger.debug("Header of md table after rename %s", md_table.head())
     rft_table = pd.merge(rft_table, md_table, on=rft_index_names, how="left")
-    logger.debug("Shape after merge %s", rft_table.shape)
-    logger.debug("Shape with no nans %s", rft_table.dropna().shape)
-    logger.debug("Head of merged table to return:\n %s", rft_table.head())
 
     return rft_table

--- a/src/fmu/sumo/sim2sumo/_special_treatments.py
+++ b/src/fmu/sumo/sim2sumo/_special_treatments.py
@@ -70,11 +70,8 @@ def find_functions_and_docstring(submod):
     Returns:
         dictionary: includes functions and doc string
     """
-    logger = logging.getLogger(__file__ + ".find_func_and_info")
-
     import_path = "res2df." + submod
     func = importlib.import_module(import_path).df
-    logger.debug("Assigning %s to %s", func.__name__, submod)
     returns = {
         "extract": func,
         "options": tuple(
@@ -94,8 +91,6 @@ def _define_submodules():
     Returns:
         list: list of submodules
     """
-
-    logger = logging.getLogger(__file__ + "define_submodules")
     package_path = Path(res2df.__file__).parent
 
     submodules = {}
@@ -111,16 +106,8 @@ def _define_submodules():
             submod = "vfp"
         try:
             submodules[submod] = find_functions_and_docstring(submod_string)
-            logger.debug("Assigning %s to %s", submodules[submod], submod)
         except AttributeError:
-            logger.debug("No df function in %s", submod_path)
-
-    logger.debug(
-        "Returning the submodule names as a list: %s ", submodules.keys()
-    )
-    logger.debug(
-        "Returning the submodules extra args as a dictionary: %s ", submodules
-    )
+            pass  # No df function in submod_path, skip it
 
     return tuple(submodules.keys()), submodules
 

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -182,7 +182,7 @@ def create_config_dict(config):
     grid3d = simconfig.get("grid3d", False)
 
     # Use the provided datafile or datatype if given, otherwise use simconfig
-    datafile = simconfig.get("datafile", None)
+    datafile = simconfig.get("datafile", [None])
     datatype = simconfig.get("datatypes", None)
 
     if datatype is None:

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -42,7 +42,8 @@ def get_case_uuid(file_path, parent_level=4):
 
     Args:
         file_path (str): path to file in ensemble
-        parent_level (int, optional): nr of levels to move down to root. Defaults to 4.
+        parent_level (int, optional): nr of levels to move down to root.
+                                        Defaults to 4.
 
     Returns:
         str: the case uuid
@@ -91,10 +92,11 @@ def filter_options(submod, kwargs):
 
 
 def find_datafiles(seedpoint=None):
-    """Find datafiles relative to an optional seedpoint or the current working directory.
+    """Find datafiles relative to seedpoint or the current working directory.
 
     Args:
-        seedpoint (str|Path|list, optional): Specific file, list of directories, or single directory to search for datafiles.
+        seedpoint (str|Path|list, optional): Where to search for datafiles.
+            Either a specific file, list of directories, or single directory.
 
     Returns:
         list: The datafiles found with unique stem names, as full paths.
@@ -105,7 +107,7 @@ def find_datafiles(seedpoint=None):
     cwd = Path().cwd()  # Get the current working directory
 
     if isinstance(seedpoint, list):
-        # If seedpoint is a list, ensure all elements are strings or Path objects
+        # Convert all elements to Path objects
         seedpoint = [Path(sp) for sp in seedpoint]
     elif seedpoint:
         seedpoint = [seedpoint]
@@ -131,7 +133,7 @@ def find_datafiles(seedpoint=None):
             else:
                 for filetype in valid_filetypes:
                     if not full_path.is_dir():
-                        # Search for valid files within the directory with partly filename
+                        # Search for valid files within the directory
                         datafiles.extend(
                             [
                                 f
@@ -415,5 +417,6 @@ def validate_sim2sumo_config(config):
     for file in datafiles:
         if isinstance(file, dict) and len(file) != 1:
             raise ValueError(
-                "Config error: datafiles specified as dictionary must have exactly one key"
+                "Config error: "
+                "datafiles specified as dictionary must have exactly one key"
             )

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -186,22 +186,21 @@ def create_config_dict(config):
     datatype = simconfig.get("datatypes", None)
 
     if datatype is None:
-        submods = ["summary", "rft", "satfunc"]
+        default_submods = ["summary", "rft", "satfunc"]
     elif datatype == "all":
-        submods = SUBMODULES
+        default_submods = SUBMODULES
     elif isinstance(datatype, list):
-        submods = datatype
+        default_submods = datatype
     else:
-        submods = [datatype]
+        default_submods = [datatype]
 
     # Initialize the dictionary to hold the configuration for each datafile
     sim2sumoconfig = {}
 
-    # If datafile is a dictionary, iterate over its items
-    if isinstance(datafile, dict):
-        for filepath, submods in datafile.items():
-            # Convert the filepath to a Path object
-            path = Path(filepath)
+    for file in datafile:
+        if isinstance(file, str):
+            # If datafile is a string
+            path = Path(file)
 
             if path.is_file():
                 # If the path is a file, use it directly, not checking filetype
@@ -209,28 +208,70 @@ def create_config_dict(config):
             # If the path is a directory or part of filename, find all matches
             else:
                 datafiles = find_datafiles(path)
-
-            # Create config entries for each datafile
             for datafile_path in datafiles:
                 sim2sumoconfig[datafile_path] = {}
-                for submod in submods:
-                    # Use the global options or default to {"arrow": True}
+                for submod in default_submods or []:
                     options = simconfig.get("options", {"arrow": True})
                     sim2sumoconfig[datafile_path][submod] = filter_options(
                         submod, options
                     )
                 sim2sumoconfig[datafile_path]["grid3d"] = grid3d
-    else:
-        # If datafile is not a dictionary, use the existing logic
-        datafiles_paths = find_datafiles(datafile)
-        for datafile_path in datafiles_paths:
-            sim2sumoconfig[datafile_path] = {}
-            for submod in submods or []:
-                options = simconfig.get("options", {"arrow": True})
-                sim2sumoconfig[datafile_path][submod] = filter_options(
-                    submod, options
-                )
-            sim2sumoconfig[datafile_path]["grid3d"] = grid3d
+        else:
+            # datafile is a dict
+            for filepath, submods in datafile.items():
+                path = Path(filepath)
+                if path.is_file():
+                    # If the path is a file, use it directly, not checking filetype
+                    datafiles = [path]
+                # If the path is a directory or part of filename, find all matches
+                else:
+                    datafiles = find_datafiles(path)
+
+                # Create config entries for each datafile
+                for datafile_path in datafiles:
+                    sim2sumoconfig[datafile_path] = {}
+                    for submod in submods:
+                        # Use the global options or default to {"arrow": True}
+                        options = simconfig.get("options", {"arrow": True})
+                        sim2sumoconfig[datafile_path][submod] = filter_options(
+                            submod, options
+                        )
+                    sim2sumoconfig[datafile_path]["grid3d"] = grid3d
+
+    # # If datafile is a dictionary, iterate over its items
+    # if isinstance(datafile, dict):
+    #     for filepath, submods in datafile.items():
+    #         # Convert the filepath to a Path object
+    #         path = Path(filepath)
+
+    #         if path.is_file():
+    #             # If the path is a file, use it directly, not checking filetype
+    #             datafiles = [path]
+    #         # If the path is a directory or part of filename, find all matches
+    #         else:
+    #             datafiles = find_datafiles(path)
+
+    #         # Create config entries for each datafile
+    #         for datafile_path in datafiles:
+    #             sim2sumoconfig[datafile_path] = {}
+    #             for submod in submods:
+    #                 # Use the global options or default to {"arrow": True}
+    #                 options = simconfig.get("options", {"arrow": True})
+    #                 sim2sumoconfig[datafile_path][submod] = filter_options(
+    #                     submod, options
+    #                 )
+    #             sim2sumoconfig[datafile_path]["grid3d"] = grid3d
+    # else:
+    #     # If datafile is not a dictionary, use the existing logic
+    #     datafiles_paths = find_datafiles(datafile)
+    #     for datafile_path in datafiles_paths:
+    #         sim2sumoconfig[datafile_path] = {}
+    #         for submod in submods or []:
+    #             options = simconfig.get("options", {"arrow": True})
+    #             sim2sumoconfig[datafile_path][submod] = filter_options(
+    #                 submod, options
+    #             )
+    #         sim2sumoconfig[datafile_path]["grid3d"] = grid3d
 
     return sim2sumoconfig
 

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -219,7 +219,7 @@ def create_config_dict(config):
                     sim2sumoconfig[datafile_path]["grid3d"] = grid3d
             else:
                 # datafile is a dict
-                for filepath, submods in datafile.items():
+                for filepath, submods in file.items():
                     path = Path(filepath)
                     if path.is_file():
                         # If the path is a file, use it directly, not checking filetype

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -186,10 +186,9 @@ def create_config_dict(config):
     datatype = simconfig.get("datatypes", None)
 
     if datatype is None:
-        submods = simconfig.get("datatypes", ["summary", "rft", "satfunc"])
-
-        if submods == "all":
-            submods = SUBMODULES
+        submods = ["summary", "rft", "satfunc"]
+    elif datatype == "all":
+        submods = SUBMODULES
     elif isinstance(datatype, list):
         submods = datatype
     else:

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -194,6 +194,8 @@ def create_config_dict(config):
 
     # Initialize the dictionary to hold the configuration for each datafile
     sim2sumoconfig = {}
+    paths = []
+    submods = default_submods
 
     if datafile:
         for file in datafile:
@@ -202,33 +204,44 @@ def create_config_dict(config):
                 submods = file_submods or default_submods
             else:
                 filepath = file
-                submods = default_submods
 
             path = Path(filepath)
             if path.is_file():
-                datafiles = [path]
+                # datafiles = [path]
+                paths += [path]
             else:
-                datafiles = find_datafiles(path)
+                # datafiles = find_datafiles(path)
+                paths += find_datafiles(path)
 
-            for datafile_path in datafiles:
-                sim2sumoconfig[datafile_path] = {}
-                for submod in submods:
-                    options = simconfig.get("options", {"arrow": True})
-                    sim2sumoconfig[datafile_path][submod] = filter_options(
-                        submod, options
-                    )
-                sim2sumoconfig[datafile_path]["grid3d"] = grid3d
+            # for datafile_path in datafiles:
+            #     sim2sumoconfig[datafile_path] = {}
+            #     for submod in submods:
+            #         options = simconfig.get("options", {"arrow": True})
+            #         sim2sumoconfig[datafile_path][submod] = filter_options(
+            #             submod, options
+            #         )
+            #     sim2sumoconfig[datafile_path]["grid3d"] = grid3d
     else:
         # If datafile is not specified, find all valid files in the current directory
-        datafiles_paths = find_datafiles(datafile)
-        for datafile_path in datafiles_paths:
-            sim2sumoconfig[datafile_path] = {}
-            for submod in default_submods:
-                options = simconfig.get("options", {"arrow": True})
-                sim2sumoconfig[datafile_path][submod] = filter_options(
-                    submod, options
-                )
-            sim2sumoconfig[datafile_path]["grid3d"] = grid3d
+        # datafiles = find_datafiles(datafile)
+        paths += find_datafiles(datafile)
+        # for datafile_path in datafiles:
+        #     sim2sumoconfig[datafile_path] = {}
+        #     for submod in default_submods:
+        #         options = simconfig.get("options", {"arrow": True})
+        #         sim2sumoconfig[datafile_path][submod] = filter_options(
+        #             submod, options
+        #         )
+        #     sim2sumoconfig[datafile_path]["grid3d"] = grid3d
+
+    for datafile_path in paths:
+        sim2sumoconfig[datafile_path] = {}
+        for submod in submods:
+            options = simconfig.get("options", {"arrow": True})
+            sim2sumoconfig[datafile_path][submod] = filter_options(
+                submod, options
+            )
+        sim2sumoconfig[datafile_path]["grid3d"] = grid3d
 
     return sim2sumoconfig
 

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -67,8 +67,6 @@ def filter_options(submod, kwargs):
     """
     logger = logging.getLogger(__file__ + ".filter_options")
     submod_options = SUBMOD_DICT[submod]["options"]
-    logger.debug("Available options for %s are %s", submod, submod_options)
-    logger.debug("Input: %s", kwargs)
     filtered = {
         key: value
         for key, value in kwargs.items()
@@ -77,11 +75,10 @@ def filter_options(submod, kwargs):
     filtered["arrow"] = kwargs.get(
         "arrow", True
     )  # defaulting of arrow happens here
-    logger.debug("After filtering options for %s: %s", submod, filtered)
     non_options = [key for key in kwargs if key not in filtered]
     if len(non_options) > 0:
         logger.warning(
-            "Filtered out options %s for %s, these are not valid",
+            "Skipping invalid options %s for %s.",
             non_options,
             submod,
         )
@@ -163,8 +160,6 @@ def find_datafiles(seedpoint=None):
         if stem not in unique_stems:
             unique_stems.add(stem)
             unique_datafiles.append(datafile.resolve())  # Resolve to full path
-        else:
-            logger.warning("Name %s from file %s already used", stem, datafile)
 
     logger.info(f"Using datafiles: {str(unique_datafiles)} ")
     return unique_datafiles
@@ -416,15 +411,12 @@ def give_name(datafile_path: str) -> str:
     Returns:
         str: derived name
     """
-    logger = logging.getLogger(__name__ + ".give_name")
-    logger.info("Giving name from path %s", datafile_path)
     datafile_path_posix = Path(datafile_path)
     base_name = datafile_path_posix.name.replace(
         datafile_path_posix.suffix, ""
     )
     while base_name[-1].isdigit() or base_name.endswith("-"):
         base_name = base_name[:-1]
-    logger.info("Returning name %s", base_name)
     return base_name
 
 

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -182,7 +182,7 @@ def create_config_dict(config):
     grid3d = simconfig.get("grid3d", False)
 
     # Use the provided datafile or datatype if given, otherwise use simconfig
-    datafile = simconfig.get("datafile", [None])
+    datafile = simconfig.get("datafile", [])
     datatype = simconfig.get("datatypes", None)
 
     if datatype is None:
@@ -197,46 +197,58 @@ def create_config_dict(config):
     # Initialize the dictionary to hold the configuration for each datafile
     sim2sumoconfig = {}
 
-    for file in datafile:
-        if isinstance(file, str):
-            # If datafile is a string
-            path = Path(file)
+    if datafile:
+        for file in datafile:
+            if isinstance(file, str):
+                # If datafile is a string
+                path = Path(file)
 
-            if path.is_file():
-                # If the path is a file, use it directly, not checking filetype
-                datafiles = [path]
-            # If the path is a directory or part of filename, find all matches
-            else:
-                datafiles = find_datafiles(path)
-            for datafile_path in datafiles:
-                sim2sumoconfig[datafile_path] = {}
-                for submod in default_submods or []:
-                    options = simconfig.get("options", {"arrow": True})
-                    sim2sumoconfig[datafile_path][submod] = filter_options(
-                        submod, options
-                    )
-                sim2sumoconfig[datafile_path]["grid3d"] = grid3d
-        else:
-            # datafile is a dict
-            for filepath, submods in datafile.items():
-                path = Path(filepath)
                 if path.is_file():
                     # If the path is a file, use it directly, not checking filetype
                     datafiles = [path]
                 # If the path is a directory or part of filename, find all matches
                 else:
                     datafiles = find_datafiles(path)
-
-                # Create config entries for each datafile
                 for datafile_path in datafiles:
                     sim2sumoconfig[datafile_path] = {}
-                    for submod in submods:
-                        # Use the global options or default to {"arrow": True}
+                    for submod in default_submods or []:
                         options = simconfig.get("options", {"arrow": True})
                         sim2sumoconfig[datafile_path][submod] = filter_options(
                             submod, options
                         )
                     sim2sumoconfig[datafile_path]["grid3d"] = grid3d
+            else:
+                # datafile is a dict
+                for filepath, submods in datafile.items():
+                    path = Path(filepath)
+                    if path.is_file():
+                        # If the path is a file, use it directly, not checking filetype
+                        datafiles = [path]
+                    # If the path is a directory or part of filename, find all matches
+                    else:
+                        datafiles = find_datafiles(path)
+
+                    # Create config entries for each datafile
+                    for datafile_path in datafiles:
+                        sim2sumoconfig[datafile_path] = {}
+                        for submod in submods:
+                            # Use the global options or default to {"arrow": True}
+                            options = simconfig.get("options", {"arrow": True})
+                            sim2sumoconfig[datafile_path][submod] = (
+                                filter_options(submod, options)
+                            )
+                        sim2sumoconfig[datafile_path]["grid3d"] = grid3d
+    else:
+        # If datafile is not specified, find all valid files in the current directory
+        datafiles_paths = find_datafiles(datafile)
+        for datafile_path in datafiles_paths:
+            sim2sumoconfig[datafile_path] = {}
+            for submod in default_submods or []:
+                options = simconfig.get("options", {"arrow": True})
+                sim2sumoconfig[datafile_path][submod] = filter_options(
+                    submod, options
+                )
+            sim2sumoconfig[datafile_path]["grid3d"] = grid3d
 
     # # If datafile is a dictionary, iterate over its items
     # if isinstance(datafile, dict):

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -427,13 +427,6 @@ def generate_meta(config, datafile_path, tagname, obj, content):
     Returns:
         dict: the metadata to export
     """
-    logger = logging.getLogger(__name__ + ".generate_meta")
-    logger.info("Obj of type: %s", type(obj))
-    logger.info("Generating metadata")
-    logger.info("Content: %s", content)
-    logger.debug("Config: %s", config)
-    logger.debug("datafile_path: %s", datafile_path)
-    logger.info("tagname: %s", tagname)
     name = give_name(datafile_path)
     exp_args = {
         "config": config,
@@ -454,7 +447,6 @@ def generate_meta(config, datafile_path, tagname, obj, content):
     metadata["file"] = {
         "relative_path": f"{relative_parent}/{name}--{tagname}".lower()
     }
-    logger.debug("Generated metadata are:\n%s", metadata)
     return metadata
 
 

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -180,9 +180,9 @@ def create_config_dict(config):
         dict: dictionary with key as path to datafile, value as dict of
               submodule and option.
     """
-    logger = logging.getLogger(__file__ + ".create_config_dict")
     simconfig = config.get("sim2sumo", {})
-    logger.debug("sim2sumo config %s", simconfig)
+    validate_sim2sumo_config(simconfig)
+
     grid3d = simconfig.get("grid3d", False)
 
     # Use the provided datafile or datatype if given, otherwise use simconfig
@@ -198,8 +198,6 @@ def create_config_dict(config):
         submods = datatype
     else:
         submods = [datatype]
-
-    logger.debug("Submodules to extract with: %s", submods)
 
     # Initialize the dictionary to hold the configuration for each datafile
     sim2sumoconfig = {}
@@ -428,3 +426,9 @@ def give_name(datafile_path: str) -> str:
         base_name = base_name[:-1]
     logger.info("Returning name %s", base_name)
     return base_name
+
+
+def validate_sim2sumo_config(config):
+    datafiles = config.get("datafile", [])
+    if not isinstance(datafiles, list):
+        raise ValueError("Config error: datafile must be a list")

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -104,6 +104,7 @@ def find_datafiles(seedpoint=None):
     datafiles = []
     cwd = Path().cwd()  # Get the current working directory
 
+    # TODO: Be stricter on seedpoint type. Should be either a list or None. If something else: raise ValueError("datafile should be a list or None")
     if isinstance(seedpoint, dict):
         # Extract the values (paths) from the dictionary and treat them as a list
         seedpoint = list(seedpoint.values())
@@ -424,3 +425,9 @@ def validate_sim2sumo_config(config):
     datafiles = config.get("datafile", [])
     if not isinstance(datafiles, list):
         raise ValueError("Config error: datafile must be a list")
+    # TODO: Uncomment and use this if it should be required that each file is a dict
+    # for file in datafiles:
+    #     if not isinstance(file, dict):
+    #         raise ValueError(
+    #             "Config error: each datafile should be a dictionary"
+    #         )

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -180,7 +180,7 @@ def create_config_dict(config):
     grid3d = simconfig.get("grid3d", False)
 
     # Use the provided datafile or datatype if given, otherwise use simconfig
-    datafile = simconfig.get("datafile", [])
+    datafile = simconfig.get("datafile", None)
     datatype = simconfig.get("datatypes", None)
 
     if datatype is None:
@@ -223,7 +223,7 @@ def create_config_dict(config):
         datafiles_paths = find_datafiles(datafile)
         for datafile_path in datafiles_paths:
             sim2sumoconfig[datafile_path] = {}
-            for submod in default_submods or []:
+            for submod in default_submods:
                 options = simconfig.get("options", {"arrow": True})
                 sim2sumoconfig[datafile_path][submod] = filter_options(
                     submod, options

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -388,9 +388,8 @@ def nodisk_upload(files, parent_id, config_path, env="prod", connection=None):
         connection (str): client to upload with
     """
     logger = logging.getLogger(__name__ + ".nodisk_upload")
-    logger.info("%s files to upload", len(files))
-    logger.info("Uploading to parent %s", parent_id)
     if len(files) > 0:
+        logger.info("Uploading %s files to parent %s", len(files), parent_id)
         if connection is None:
             connection = SumoConnection(env=env)
         status = upload_files(

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -170,13 +170,11 @@ def find_datafiles(seedpoint=None):
     return unique_datafiles
 
 
-def create_config_dict(config, datafile=None, datatype=None):
+def create_config_dict(config):
     """Read config settings and make dictionary for use when exporting.
 
     Args:
         config (dict): the settings for export of simulator results.
-        datafile (str|Path|list, None): overrule with one datafile or list of datafiles.
-        datatype (str|list, None): overrule with one datatype or a list of datatypes.
 
     Returns:
         dict: dictionary with key as path to datafile, value as dict of
@@ -188,12 +186,8 @@ def create_config_dict(config, datafile=None, datatype=None):
     grid3d = simconfig.get("grid3d", False)
 
     # Use the provided datafile or datatype if given, otherwise use simconfig
-    datafile = (
-        datafile if datafile is not None else simconfig.get("datafile", None)
-    )
-    datatype = (
-        datatype if datatype is not None else simconfig.get("datatypes", None)
-    )
+    datafile = simconfig.get("datafile", None)
+    datatype = simconfig.get("datatypes", None)
 
     if datatype is None:
         submods = simconfig.get("datatypes", ["summary", "rft", "satfunc"])

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -104,8 +104,6 @@ def find_datafiles(seedpoint=None):
     datafiles = []
     cwd = Path().cwd()  # Get the current working directory
 
-    # TODO? Validate that seedpoint is either str, Path, list or None?
-
     if isinstance(seedpoint, list):
         # If seedpoint is a list, ensure all elements are strings or Path objects
         seedpoint = [Path(sp) for sp in seedpoint]
@@ -192,10 +190,11 @@ def create_config_dict(config):
     else:
         default_submods = [datatype]
 
+    submods = default_submods
+
     # Initialize the dictionary to hold the configuration for each datafile
     sim2sumoconfig = {}
     paths = []
-    submods = default_submods
 
     if datafile:
         for file in datafile:
@@ -207,32 +206,11 @@ def create_config_dict(config):
 
             path = Path(filepath)
             if path.is_file():
-                # datafiles = [path]
                 paths += [path]
             else:
-                # datafiles = find_datafiles(path)
                 paths += find_datafiles(path)
-
-            # for datafile_path in datafiles:
-            #     sim2sumoconfig[datafile_path] = {}
-            #     for submod in submods:
-            #         options = simconfig.get("options", {"arrow": True})
-            #         sim2sumoconfig[datafile_path][submod] = filter_options(
-            #             submod, options
-            #         )
-            #     sim2sumoconfig[datafile_path]["grid3d"] = grid3d
     else:
-        # If datafile is not specified, find all valid files in the current directory
-        # datafiles = find_datafiles(datafile)
         paths += find_datafiles(datafile)
-        # for datafile_path in datafiles:
-        #     sim2sumoconfig[datafile_path] = {}
-        #     for submod in default_submods:
-        #         options = simconfig.get("options", {"arrow": True})
-        #         sim2sumoconfig[datafile_path][submod] = filter_options(
-        #             submod, options
-        #         )
-        #     sim2sumoconfig[datafile_path]["grid3d"] = grid3d
 
     for datafile_path in paths:
         sim2sumoconfig[datafile_path] = {}

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -107,13 +107,11 @@ def upload_init(init_path, xtgeoegrid, config, dispatcher):
         int: number of objects to export
     """
     logger = logging.getLogger(__name__ + ".upload_init")
-    logger.debug("File to load init from %s", init_path)
     unwanted = ["ENDNUM", "DX", "DY", "DZ", "TOPS"]
     init_props = list(
         eclrun.find_gridprop_from_init_file(init_path, "all", xtgeoegrid)
     )
     count = 0
-    logger.debug("%s properties found in init", len(init_props))
     for init_prop in init_props:
         if init_prop["name"] in unwanted:
             logger.warning("%s will not be exported", init_prop["name"])
@@ -134,7 +132,7 @@ def upload_init(init_path, xtgeoegrid, config, dispatcher):
             continue
         dispatcher.add(sumo_file)
         count += 1
-    logger.info("%s properties sendt on", count)
+    logger.info("%s properties set for upload", count)
     return count
 
 
@@ -158,7 +156,6 @@ def upload_restart(
         int: number of objects to export
     """
     logger = logging.getLogger(__name__ + ".upload_restart")
-    logger.debug("File to load restart from %s", restart_path)
     count = 0
     for prop_name in prop_names:
         for time_step in time_steps:
@@ -172,7 +169,6 @@ def upload_restart(
 
             xtgeo_prop = make_xtgeo_prop(xtgeoegrid, restart_prop)
             if xtgeo_prop is not None:
-                logger.debug("Exporting %s", xtgeo_prop.name)
                 sumo_file = convert_xtgeo_2_sumo_file(
                     restart_path, xtgeo_prop, "UNRST", config
                 )
@@ -211,7 +207,7 @@ def upload_simulation_run(datafile, config, dispatcher):
         datafile (str): path to datafile
     """
     logger = logging.getLogger(__name__ + ".upload_simulation_run")
-    datafile_path = Path(datafile)
+    datafile_path = Path(datafile).resolve()
     init_path = str(datafile_path.with_suffix(".INIT"))
     restart_path = str(datafile_path.with_suffix(".UNRST"))
     grid_path = str(datafile_path.with_suffix(".EGRID"))
@@ -259,15 +255,12 @@ def make_xtgeo_prop(xtgeoegrid, prop_dict):
     Returns:
         xtgeo.GridProperty: the extracted results
     """
-    logger = logging.getLogger(__name__ + ".make_xtgeo_prop")
     prop_name = prop_dict["name"]
     values = prop_dict["values"]
+    # TODO: Why do we skip single value properties?
     single_value = np.unique(values).size == 1
     if single_value:
-        logger.debug(
-            "%s has only one value. Will not return single value property.",
-            prop_name,
-        )
+        # prop_name has only one value. Will not return single value property."
         return None
 
     xtgeo_prop = GridProperty(xtgeoegrid, name=prop_name)

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -74,13 +74,15 @@ def convert_xtgeo_2_sumo_file(datafile, obj, prefix, config):
     """Convert xtgeo object to SumoFile ready for shipping to Sumo
 
     Args:
-        datafile (str|PosixPath): path to datafile connected to extracted object
+        datafile (str|PosixPath):
+            path to datafile connected to extracted object
         obj (Xtgeo object): The object to prepare for upload
         prefix (str): prefix to distinguish between init and restart
         config (dict): dictionary with master metadata needed for Sumo
 
     Returns:
-        SumoFile: Object containing xtgeo object as bytestring + metadata as dictionary
+        SumoFile: Object containing xtgeo object as bytestring
+                    and metadata as dictionary
     """
     if obj is None:
         return obj
@@ -150,7 +152,8 @@ def upload_restart(
         restart_path (str): path to restart file
         xtgeoegrid (xtge.Grid): the grid to unpack the properties to
         time_steps (list): the timesteps to use
-        prop_names (iterable, optional): the properties to export. Defaults to ("SWAT", "SGAS", "SOIL", "PRESSURE").
+        prop_names (iterable, optional): the properties to export.
+                    Defaults to ("SWAT", "SGAS", "SOIL", "PRESSURE").
 
     Returns:
         int: number of objects to export
@@ -174,7 +177,7 @@ def upload_restart(
                 )
                 if sumo_file is None:
                     logger.warning(
-                        "Property with name %s extracted from %s returned nothing",
+                        "Property %s extracted from %s returned nothing",
                         prop_name,
                         restart_path,
                     )

--- a/src/fmu/sumo/sim2sumo/hook_implementations/jobs.py
+++ b/src/fmu/sumo/sim2sumo/hook_implementations/jobs.py
@@ -13,18 +13,19 @@ This is done by SIM2SUMO in a three step process:
 1. Data is extracted in arrow format using res2df
 2. Corresponding metadata are generated via fmu-dataio
 3. Data and metadata are then uploaded to Sumo using fmu-sumo-upload
-SIM2SUMO is set up to automatically extract summary, rft and well completion data, but
+SIM2SUMO defaults to extract summary, rft and well completion data, but
 you can configure it to extract any datatype that res2df can produce.
 
-SIM2SUMO autodetects results from your the eclipse/model/ folder in your realization.
-Basically looking for files with suffix .DATA, and then going on to finding the eclipse
-run results. This means that if you have more than one eclipse run in that folder, you will
-get the specified result from all those runs. The results will be stored in sumo with
-name <name of datafile> where the habituary -<IENS> at the end is removed,
-tagname will be name of datatype extracted.
+SIM2SUMO finds results from the eclipse/model/ folder in your realization.
+It looks for files with suffix .DATA, and then finds the eclipse run results.
+This means that if you have more than one eclipse run in that folder, you will
+get the specified result from all those runs.
+The results are stored in Sumo with name <name of datafile> without the
+habituary -<IENS> at the end.
+Tagname will be name of datatype extracted.
 
-E.G: summary files extracted from an eclipse run names DROGON-1, will be stored in
-sumo with name: DROGON, tagname: summary, and fmu.realization.id: 1
+E.G: summary files extracted from an eclipse run named DROGON-1, will be
+stored in Sumo with name: DROGON, tagname: summary, and fmu.realization.id: 1
 
  Pre-requisites: SIM2SUMO is dependent on a configuration yaml file.
                 (defaulted to ../../fmuconfig/output/global_variables.yml).
@@ -48,10 +49,9 @@ EXAMPLES = """
    --Note: SIM2SUMO must come after ECLIPSE100
    FORWARD_MODEL SIM2SUMO(<S2S_CONFIG_PATH>=path/to/config/file)
 
-3. When you want to configure the fmu_config file to control what SIM2SUMO produces
+3. When you want to configure the fmu_config file to control what SIM2SUMO
+   produces add section sim2sumo to your fmu_config file.
    (for inclusion of the forward model in your ert setup see examples 1. or 2.)
-   add section sim2sumo to your fmu_config file. Documentation of how to do this is
-   under construction, for now contact Daniel Sollien (dbs) for help.
 """
 PLUGIN_NAME = "SIM2SUMO"
 

--- a/src/fmu/sumo/sim2sumo/main.py
+++ b/src/fmu/sumo/sim2sumo/main.py
@@ -70,7 +70,11 @@ def main():
     config = yaml_load(args.config_path)
     config["file_path"] = args.config_path
     logger.debug("Added file_path, and config keys are %s", config.keys())
-    sim2sumoconfig = create_config_dict(config)
+    try:
+        sim2sumoconfig = create_config_dict(config)
+    except Exception as e:
+        logger.error("Failed to create config dict: %s", e)
+        return
     # Init of dispatcher needs one datafile to locate case uuid
     one_datafile = list(sim2sumoconfig.keys())[0]
     try:

--- a/src/fmu/sumo/sim2sumo/main.py
+++ b/src/fmu/sumo/sim2sumo/main.py
@@ -33,18 +33,6 @@ def parse_args():
         help="Which sumo environment to upload to",
         default="prod",
     )
-    parser.add_argument(
-        "--datatype",
-        type=str,
-        default=None,
-        help="Override datatype setting, for testing only",
-    )
-    parser.add_argument(
-        "--datafile",
-        type=str,
-        default=None,
-        help="Override datafile setting, for testing only",
-    )
     parser.add_argument("--d", help="Activate debug mode", action="store_true")
     args = parser.parse_args()
     if args.d:
@@ -82,7 +70,7 @@ def main():
     config = yaml_load(args.config_path)
     config["file_path"] = args.config_path
     logger.debug("Added file_path, and config keys are %s", config.keys())
-    sim2sumoconfig = create_config_dict(config, args.datafile, args.datatype)
+    sim2sumoconfig = create_config_dict(config)
     # Init of dispatcher needs one datafile to locate case uuid
     one_datafile = list(sim2sumoconfig.keys())[0]
     try:

--- a/src/fmu/sumo/sim2sumo/main.py
+++ b/src/fmu/sumo/sim2sumo/main.py
@@ -43,6 +43,8 @@ def parse_args():
     return args
 
 
+# e.g. _ERT_RUNPATH = ../realization-0/iter-0
+# e.g. _ERT_EXPERIMENT_ID = <uuid>
 # fmu-dataio needs these when creating metadata
 REQUIRED_ENV_VARS = ["_ERT_EXPERIMENT_ID", "_ERT_RUNPATH"]
 

--- a/src/fmu/sumo/sim2sumo/main.py
+++ b/src/fmu/sumo/sim2sumo/main.py
@@ -59,7 +59,9 @@ def main():
 
     if missing > 0:
         print(
-            "Required ERT environment variables not found. This can happen if sim2sumo was called outside the ERT context. Stopping."
+            "Required ERT environment variables not found. "
+            "This can happen if sim2sumo was called outside the ERT context. "
+            "Stopping."
         )
         exit()
 

--- a/src/fmu/sumo/sim2sumo/main.py
+++ b/src/fmu/sumo/sim2sumo/main.py
@@ -70,7 +70,9 @@ def main():
             missing += 1
 
     if missing > 0:
-        print("Required ERT environment variables not found. This can happen if sim2sumo was called outside the ERT context. Stopping.")
+        print(
+            "Required ERT environment variables not found. This can happen if sim2sumo was called outside the ERT context. Stopping."
+        )
         exit()
 
     args = parse_args()

--- a/src/fmu/sumo/sim2sumo/main.py
+++ b/src/fmu/sumo/sim2sumo/main.py
@@ -15,7 +15,6 @@ def parse_args():
     Returns:
         argparse.NameSpace: the arguments parsed
     """
-    logger = logging.getLogger(__file__ + ".parse_args")
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description="Parsing input to control export of simulator data",
@@ -39,7 +38,6 @@ def parse_args():
         logging.basicConfig(
             level="DEBUG", format="%(name)s - %(levelname)s - %(message)s"
         )
-    logger.debug("Returning args %s", vars(args))
     return args
 
 
@@ -66,12 +64,9 @@ def main():
         exit()
 
     args = parse_args()
-    logger.debug("Running with arguments %s", args)
 
-    logger.info("Will be extracting results")
     config = yaml_load(args.config_path)
     config["file_path"] = args.config_path
-    logger.debug("Added file_path, and config keys are %s", config.keys())
     try:
         sim2sumoconfig = create_config_dict(config)
     except Exception as e:
@@ -87,10 +82,10 @@ def main():
         logger.error("Failed to create dispatcher: %s", e)
         return
 
-    logger.debug("Extracting tables")
+    # Extract tables
     upload_tables(sim2sumoconfig, config, dispatcher)
 
-    logger.debug("Extracting 3dgrid(s) with properties")
+    # Extract 3dgrid(s) with properties
     upload_simulation_runs(sim2sumoconfig, config, dispatcher)
 
     dispatcher.finish()

--- a/src/fmu/sumo/sim2sumo/tables.py
+++ b/src/fmu/sumo/sim2sumo/tables.py
@@ -231,14 +231,14 @@ def upload_tables_from_simulation_run(
             )
         else:
             table = get_table(datafile, submod, **options)
-            sumo_file = convert_table_2_sumo_file(
-                datafile, table, submod, config
-            )
-            if sumo_file is None:
+            if table is None:
                 logger.warning(
                     "Table with datatype %s extracted from %s returned nothing",
                     submod,
                     datafile,
                 )
                 continue
+            sumo_file = convert_table_2_sumo_file(
+                datafile, table, submod, config
+            )
             dispatcher.add(sumo_file)

--- a/src/fmu/sumo/sim2sumo/tables.py
+++ b/src/fmu/sumo/sim2sumo/tables.py
@@ -118,12 +118,11 @@ def get_table(
             "arrow"
         ]  # This argument should not be passed to extract function
     except KeyError:
-        logger.debug("No arrow key to delete")
+        pass  # No arrow key to delete
     output = None
     # TODO: see if there is a cleaner way with rft, see functions
     # find_md_log, and complete_rft, but needs really to be fixed in res2df
     md_log_file = find_md_log(submod, kwargs)
-    logger.debug("Checking these passed options %s", kwargs)
     try:
         logger.info(
             "Extracting data from %s with func %s for %s",
@@ -141,18 +140,11 @@ def get_table(
         if arrow:
             try:
                 convert_func = SUBMOD_DICT[submod]["arrow_convertor"]
-                logger.debug(
-                    "Using function %s to convert to arrow",
-                    convert_func.__name__,
-                )
                 output = convert_func(output)
             except pa.lib.ArrowInvalid:
                 logger.warning(
-                    "Arrow invalid, cannot convert to arrow, keeping pandas format, (trace %s)",
+                    "Arrow invalid, cannot convert to arrow, keeping pandas format, (trace %s). \nFalling back to converting with %s",
                     sys.exc_info()[1],
-                )
-                logger.debug(
-                    "Falling back to converting with %s",
                     convert_to_arrow.__name__,
                 )
                 output = convert_to_arrow(output)

--- a/src/fmu/sumo/sim2sumo/tables.py
+++ b/src/fmu/sumo/sim2sumo/tables.py
@@ -135,7 +135,6 @@ def get_table(
             **kwargs,
         )
         if submod == "rft":
-
             output = complete_rft(output, md_log_file)
         if arrow:
             try:
@@ -148,7 +147,6 @@ def get_table(
                     convert_to_arrow.__name__,
                 )
                 output = convert_to_arrow(output)
-
             except TypeError:
                 logger.warning("Type error, cannot convert to arrow")
 
@@ -168,8 +166,6 @@ def upload_tables(sim2sumoconfig, config, dispatcher):
         config (dict): the fmu config file with metadata
         env (str): what environment to upload to
     """
-    logger = logging.getLogger(__file__ + ".upload_tables")
-    logger.debug("Will upload with settings %s", sim2sumoconfig)
     for datafile_path, submod_and_options in sim2sumoconfig.items():
         datafile_path = datafile_path.resolve()
         upload_tables_from_simulation_run(

--- a/src/fmu/sumo/sim2sumo/tables.py
+++ b/src/fmu/sumo/sim2sumo/tables.py
@@ -81,7 +81,8 @@ def convert_table_2_sumo_file(datafile, obj, tagname, config):
         tagname (str): what submodule the table is extracted from
         config (dict): dictionary with master metadata needed for Sumo
     Returns:
-         SumoFile: Object containing table object as bytestring + metadata as dictionary
+        SumoFile: Object containing table object as bytestring and
+            metadata as dictionary
     """
     if obj is None:
         return obj
@@ -142,7 +143,9 @@ def get_table(
                 output = convert_func(output)
             except pa.lib.ArrowInvalid:
                 logger.warning(
-                    "Arrow invalid, cannot convert to arrow, keeping pandas format, (trace %s). \nFalling back to converting with %s",
+                    "Arrow invalid, cannot convert to arrow, "
+                    "keeping pandas format, "
+                    "(trace %s). \nFalling back to converting with %s",
                     sys.exc_info()[1],
                     convert_to_arrow.__name__,
                 )
@@ -224,7 +227,7 @@ def upload_tables_from_simulation_run(
             table = get_table(datafile, submod, **options)
             if table is None:
                 logger.warning(
-                    "Table with datatype %s extracted from %s returned nothing",
+                    "Table with datatype %s from %s returned nothing",
                     submod,
                     datafile,
                 )

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -50,7 +50,7 @@ def check_sumo(case_uuid, tag_prefix, correct, class_type, sumo):
         query += f" AND class:{class_type}"
         check_nr = correct
     else:
-        # The plus one is because we are always uploading the parameters.txt automatically
+        # Plus one because we always upload parameters.txt automatically
         check_nr = correct + 1
 
     results = sumo.get(path, query).json()
@@ -320,17 +320,19 @@ def test_submodules_dict():
     "submod",
     (name for name in SUBMODULES if name != "wellcompletiondata"),
 )
-# Skipping wellcompletion data, since this needs zonemap, which none of the others do
+# Skipping wellcompletion data, since this requires zonemap
 def test_get_table(submod):
     """Test fetching of dataframe"""
     frame = tables.get_table(REEK_DATA_FILE, submod, arrow=False)
-    assert isinstance(
-        frame, pd.DataFrame
-    ), f"Call for get_table with arrow=False should produce dataframe, but produces {type(frame)}"
+    assert isinstance(frame, pd.DataFrame), (
+        "get_table with arrow=False should return dataframe,"
+        f" but returned {type(frame)}"
+    )
     frame = tables.get_table(REEK_DATA_FILE, submod, arrow=True)
-    assert isinstance(
-        frame, pa.Table
-    ), f"Call for get_table with arrow=True should produce pa.Table, but produces {type(frame)}"
+    assert isinstance(frame, pa.Table), (
+        "get_table with arrow=True should return pa.Table,"
+        f" but returned {type(frame)}"
+    )
     if submod == "summary":
         assert (
             frame.schema.field("FOPT").metadata is not None
@@ -358,7 +360,7 @@ def test_find_datafiles_reek(real, nrdfiles):
     expected_tools = ["eclipse", "opm", "ix", "pflotran"]
     assert (
         len(datafiles) == nrdfiles
-    ), f"Incorrect number of datafiles found. Expected {nrdfiles} but found {len(datafiles)}"
+    ), f"Expected {nrdfiles} datafiles but found {len(datafiles)}"
     for found_path in datafiles:
         parent = found_path.parent.parent.name
         assert parent in expected_tools, f"|{parent}| not in {expected_tools}"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -118,16 +118,12 @@ def test_get_case_uuid(case_uuid, scratch_files, monkeypatch):
     [
         ({}, 5, 4),
         (
-            {
-                "datafile": {
-                    "3_R001_REEK": {"summary": {"column_keys": "F*P*"}}
-                }
-            },
+            {"datafile": [{"3_R001_REEK": ["summary"]}]},
             1,
             2,
         ),
         (
-            {"datafile": {"3_R001_REEK": ["summary", "rft"]}},
+            {"datafile": [{"3_R001_REEK": ["summary", "rft"]}]},
             1,
             3,
         ),

--- a/tests/test_with_ert.py
+++ b/tests/test_with_ert.py
@@ -23,7 +23,7 @@ def write_ert_config_and_run(runpath):
         stdout, stderr = process.communicate()
 
     print(
-        f"After ert run all these files where found at runpath {[item.name for item in list(Path(runpath).glob('*'))]}"
+        f"After ert run all these files were found at runpath {[item.name for item in list(Path(runpath).glob('*'))]}"
     )
     if stdout:
         print("stdout:", stdout.decode(encoding), sep="\n")

--- a/tests/test_with_ert.py
+++ b/tests/test_with_ert.py
@@ -1,5 +1,7 @@
-# When ERT runs it makes changes to the files. This can cause issues for other tests if they expect certain files to exist etc.
-# Tests that run ERT should therefore create their own temporary file structure, completely separate from other tests.
+# When ERT runs it makes changes to the files.
+# This can cause issues for other tests if they expect certain files
+# to exist etc. Tests that run ERT should therefore create their own
+# temporary file structure, completely separate from other tests.
 from pathlib import Path
 
 from subprocess import PIPE, Popen
@@ -13,7 +15,10 @@ def write_ert_config_and_run(runpath):
     with open(ert_full_config_path, "w", encoding=encoding) as stream:
 
         stream.write(
-            f"DEFINE <SUMO_ENV> dev\nNUM_REALIZATIONS 1\nMAX_SUBMIT 1\nRUNPATH {runpath}\nFORWARD_MODEL SIM2SUMO"
+            (
+                "DEFINE <SUMO_ENV> dev\nNUM_REALIZATIONS 1\nMAX_SUBMIT"
+                f" 1\nRUNPATH {runpath}\nFORWARD_MODEL SIM2SUMO"
+            )
         )
     with Popen(
         ["ert", "test_run", str(ert_full_config_path)],
@@ -23,7 +28,10 @@ def write_ert_config_and_run(runpath):
         stdout, stderr = process.communicate()
 
     print(
-        f"After ert run all these files were found at runpath {[item.name for item in list(Path(runpath).glob('*'))]}"
+        (
+            "After ERT run these files were found at runpath:"
+            f"{[item.name for item in list(Path(runpath).glob('*'))]}"
+        )
     )
     if stdout:
         print("stdout:", stdout.decode(encoding), sep="\n")
@@ -46,7 +54,7 @@ def test_sim2sumo_with_ert(
 ):
     monkeypatch.chdir(ert_run_scratch_files[0])
     real0 = ert_run_scratch_files[0]
-    # After this the files in the current directory are changed and parameters.txt no longer exists
+    # ! This changes files in the current directory and deletes parameters.txt
     write_ert_config_and_run(real0)
     expected_exports = 88
     path = f"/objects('{ert_run_case_uuid}')/search"


### PR DESCRIPTION
* Reduce some flexibility in regards to config. `datafile` now has to be a list where each element is either a filepath, folderpath or a dictionary with key=filepath/folderpath and value=list of filetypes.
* Also, `datatypes` has to be a list
* Remove verbose logging
* Remove `--datatype` and `--datafile` arguments from main function. These were only for test use.
* Validate `datafile` in config is a list and dictionary elements have exactly 1 key.
* Refactor parsing of `datafile` from config
* Do not crash if failing to `create_config_dict`. Instead, log error and return.
* Formatting

Possibly related to #87 