### PR TITLE
chore: Drop support for Python 3.8

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
       max-parallel: 1
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ line-length = 79
 
 [project]
 name = "fmu-sumo-sim2sumo"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
   "sumo-wrapper-python>=1.0.3",


### PR DESCRIPTION
`fmu-sumo-uploader` no longer supports Python 3.8 https://github.com/equinor/fmu-sumo-uploader/pull/109

Remove support from sim2sumo as well.