### PR TITLE
Link grid properties to a geometry

### DIFF
--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -72,16 +72,15 @@ def generate_grid3d_meta(datafile, obj, config):
         exp_args["timedata"] = [[datefield]]
 
     exd = ExportData(**exp_args)
+    # TODO: Possible to only do .export() and get metadata from there?
     metadata = exd.generate_metadata(obj)
     outgrid = exd.export(obj)
-    print(f"OUTGRID: {outgrid}")
     relative_parent = str(Path(datafile).parents[2]).replace(
         str(Path(datafile).parents[4]), ""
     )
     metadata["file"][
         "relative_path"
     ] = f"{relative_parent}/{tagname}--{name}".lower()
-    print(f"METADATA FILE: {metadata['file']}")
     assert isinstance(
         metadata, dict
     ), f"meta should be dict, but is {type(metadata)}"
@@ -267,19 +266,13 @@ def upload_simulation_run(datafile, config, dispatcher):
     dispatcher.add(sumo_file)
     time_steps = get_timesteps(restart_path, egrid)
 
-    grid_metadata_abs_path = grid_metadata["file"]["absolute_path"]
-    # TODO: Use dataio.export instead of NamedTempFile
+    grid_abs_path = grid_metadata["file"]["absolute_path"]
     # TODO: Delete the files written to disk after upload to Sumo is done
-    # with namedtmpfile:
-    #   write grid data to the tmp file
-    #   use the tmp file to link geometry to grid properties
-    # with NamedTemporaryFile(suffix=".yml", mode="w+t") as temp_file:
-    #     yaml.dump(grid_metadata, temp_file)
-    #     # temp_file.write(grid_metadata)
-    #     # temp_file.seek(0)
 
-    upload_init(init_path, xtgeoegrid, config, dispatcher)
-    upload_restart(restart_path, xtgeoegrid, time_steps, config, dispatcher)
+    upload_init(init_path, xtgeoegrid, config, dispatcher, grid_abs_path)
+    upload_restart(
+        restart_path, xtgeoegrid, time_steps, config, dispatcher, grid_abs_path
+    )
 
 
 def get_timesteps(restart_path, egrid):

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -180,6 +180,7 @@ def upload_init(init_path, xtgeoegrid, config, dispatcher, geometry_path):
             logger.warning("%s will not be exported", init_prop["name"])
             continue
         xtgeo_prop = make_xtgeo_prop(xtgeoegrid, init_prop)
+        xtgeo_prop.geometry = xtgeoegrid
         if xtgeo_prop is None:
             logger.warning("%s will not be uploaded", init_prop["name"])
             continue
@@ -223,6 +224,7 @@ def upload_restart(
                 continue
 
             xtgeo_prop = make_xtgeo_prop(xtgeoegrid, restart_prop)
+            xtgeo_prop.geometry = xtgeoegrid
             if xtgeo_prop is not None:
                 prop_metadata = generate_gridproperty_meta(
                     restart_path, xtgeo_prop, "UNRST", config, geometry_path
@@ -317,6 +319,6 @@ def make_xtgeo_prop(xtgeoegrid, prop_dict):
         # prop_name has only one value. Will not return single value property."
         return None
 
-    xtgeo_prop = GridProperty(xtgeoegrid, name=prop_name, linkgeometry=True)
+    xtgeo_prop = GridProperty(xtgeoegrid, name=prop_name)
     xtgeo_prop.values = values
     return xtgeo_prop

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -87,9 +87,9 @@ def generate_grid3d_meta(datafile, obj, config):
     metadata["file"]["relative_path"] = (
         f"{relative_parent}/{tagname}--{name}".lower()
     )
-    assert isinstance(
-        metadata, dict
-    ), f"meta should be dict, but is {type(metadata)}"
+    assert isinstance(metadata, dict), (
+        f"meta should be dict, but is {type(metadata)}"
+    )
 
     return metadata
 
@@ -129,9 +129,9 @@ def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
     metadata["file"]["relative_path"] = (
         f"{relative_parent}/{tagname}--{name}".lower()
     )
-    assert isinstance(
-        metadata, dict
-    ), f"meta should be dict, but is {type(metadata)}"
+    assert isinstance(metadata, dict), (
+        f"meta should be dict, but is {type(metadata)}"
+    )
 
     return metadata
 

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -43,7 +43,8 @@ def xtgeo_2_bytestring(obj):
     return bytestring
 
 
-# Almost equal to tables.py::generate_table_meta, but note difference in name and tagname
+# Almost equal to tables.py::generate_table_meta,
+# difference in name and tagname
 def generate_grid3d_meta(datafile, obj, config):
     """Generate metadata for xtgeo object
 
@@ -77,9 +78,9 @@ def generate_grid3d_meta(datafile, obj, config):
     relative_parent = str(Path(datafile).parents[2]).replace(
         str(Path(datafile).parents[4]), ""
     )
-    metadata["file"][
-        "relative_path"
-    ] = f"{relative_parent}/{tagname}--{name}".lower()
+    metadata["file"]["relative_path"] = (
+        f"{relative_parent}/{tagname}--{name}".lower()
+    )
     assert isinstance(
         metadata, dict
     ), f"meta should be dict, but is {type(metadata)}"
@@ -87,7 +88,8 @@ def generate_grid3d_meta(datafile, obj, config):
     return metadata
 
 
-# Almost equal to generate_grid3d_meta, difference in name, content and geometry
+# Almost equal to generate_grid3d_meta
+# difference in name, content and geometry
 def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
     """Generate metadata for xtgeo object
 
@@ -96,7 +98,7 @@ def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
         obj (xtgeo object): the object to generate metadata on
         prefix (str): prefix to include
         config (dict): the fmu config file
-        geogrid (str): path to the grid to to link as geometry to the grid property
+        geogrid (str): path to the grid to link as geometry
 
     Returns:
         dict: the metadata for obj
@@ -120,9 +122,9 @@ def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
     relative_parent = str(Path(datafile).parents[2]).replace(
         str(Path(datafile).parents[4]), ""
     )
-    metadata["file"][
-        "relative_path"
-    ] = f"{relative_parent}/{tagname}--{name}".lower()
+    metadata["file"]["relative_path"] = (
+        f"{relative_parent}/{tagname}--{name}".lower()
+    )
     assert isinstance(
         metadata, dict
     ), f"meta should be dict, but is {type(metadata)}"
@@ -263,7 +265,8 @@ def upload_simulation_run(datafile, config, dispatcher):
     xtgeoegrid = grid_from_file(grid_path)
     grid_metadata = generate_grid3d_meta(restart_path, xtgeoegrid, config)
 
-    # TODO: Have to get absolute_path here, because FileOnJob in convert_xtgeo_to_sumo_file
+    # TODO: Have to get absolute_path here,
+    #       because FileOnJob in convert_xtgeo_to_sumo_file
     #       sets file.absolute_path to "".  Why?
     grid_abs_path = grid_metadata["file"]["absolute_path"]
 

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -73,7 +73,7 @@ def generate_grid3d_meta(datafile, obj, config):
     #       export() calls generate_metadata() and puts it into a file.
     #       Can just read that file instead of doing generate_metadata() again.
     metadata = exd.generate_metadata(obj)
-    outgrid = exd.export(obj)
+    exd.export(obj)
     relative_parent = str(Path(datafile).parents[2]).replace(
         str(Path(datafile).parents[4]), ""
     )

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -42,33 +42,25 @@ def xtgeo_2_bytestring(obj):
 
 
 # Almost equal to tables.py::generate_table_meta, but note difference in name and tagname
-def generate_grid3d_meta(datafile, obj, prefix, config):
+def generate_grid3d_meta(datafile, obj, config):
     """Generate metadata for xtgeo object
 
     Args:
         datafile (str): path to datafile
         obj (xtgeo object): the object to generate metadata on
-        prefix (str): prefix to include
         config (dict): the fmu config file
 
     Returns:
         dict: the metadata for obj
     """
-    if isinstance(obj, Grid):
-        content = "depth"
-    else:
-        content = {"property": {"is_discrete": False}}
 
-    if prefix == "grid":
-        name = prefix
-    else:
-        name = f"{prefix}-{obj.name}"
+    name = "grid"
     tagname = give_name(datafile)
     exp_args = {
         "config": config,
         "name": name,
         "tagname": tagname,
-        "content": content,
+        "content": "depth",
     }
     datefield = find_datefield(tagname)
     if datefield is not None:
@@ -89,15 +81,55 @@ def generate_grid3d_meta(datafile, obj, prefix, config):
     return metadata
 
 
-def convert_xtgeo_2_sumo_file(datafile, obj, prefix, config):
-    """Convert xtgeo object to SumoFile ready for shipping to Sumo
+# Almost equal to generate_grid3d_meta, difference in name, content and geometry
+def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
+    """Generate metadata for xtgeo object
 
     Args:
-        datafile (str|PosixPath):
-            path to datafile connected to extracted object
+        datafile (str): path to datafile
+        obj (xtgeo object): the object to generate metadata on
+        prefix (str): prefix to include
+        config (dict): the fmu config file
+        geogrid (xtgeo grid): geometry to link to the grid property
+
+    Returns:
+        dict: the metadata for obj
+    """
+
+    name = f"{prefix}-{obj.name}"
+    tagname = give_name(datafile)
+    exp_args = {
+        "config": config,
+        "name": name,
+        "tagname": tagname,
+        "content": {"property": {"is_discrete": False}},
+        "geometry": geogrid,
+    }
+    datefield = find_datefield(tagname)
+    if datefield is not None:
+        exp_args["timedata"] = [[datefield]]
+
+    exd = ExportData(**exp_args)
+    metadata = exd.generate_metadata(obj)
+    relative_parent = str(Path(datafile).parents[2]).replace(
+        str(Path(datafile).parents[4]), ""
+    )
+    metadata["file"] = {
+        "relative_path": f"{relative_parent}/{tagname}--{name}".lower()
+    }
+    assert isinstance(
+        metadata, dict
+    ), f"meta should be dict, but is {type(metadata)}"
+
+    return metadata
+
+
+def convert_xtgeo_2_sumo_file(obj, metadata):
+    """Convert xtgeo object to SumoFile
+
+    Args:
         obj (Xtgeo object): The object to prepare for upload
-        prefix (str): prefix to distinguish between init and restart
-        config (dict): dictionary with master metadata needed for Sumo
+        metadata (dict): dictionary with metadata
 
     Returns:
         SumoFile: Object containing xtgeo object as bytestring
@@ -107,7 +139,6 @@ def convert_xtgeo_2_sumo_file(datafile, obj, prefix, config):
         return obj
 
     bytestring = xtgeo_2_bytestring(obj)
-    metadata = generate_grid3d_meta(datafile, obj, prefix, config)
 
     sumo_file = FileOnJob(bytestring, metadata)
     sumo_file.path = metadata["file"]["relative_path"]
@@ -140,9 +171,10 @@ def upload_init(init_path, xtgeoegrid, config, dispatcher):
         if xtgeo_prop is None:
             logger.warning("%s will not be uploaded", init_prop["name"])
             continue
-        sumo_file = convert_xtgeo_2_sumo_file(
-            init_path, xtgeo_prop, "INIT", config
+        prop_metadata = generate_gridproperty_meta(
+            init_path, xtgeo_prop, "INIT", config, xtgeoegrid
         )
+        sumo_file = convert_xtgeo_2_sumo_file(xtgeo_prop, prop_metadata)
         if sumo_file is None:
             logger.warning(
                 "Property with name %s extracted from %s returned nothing",
@@ -178,8 +210,11 @@ def upload_restart(restart_path, xtgeoegrid, time_steps, config, dispatcher):
 
             xtgeo_prop = make_xtgeo_prop(xtgeoegrid, restart_prop)
             if xtgeo_prop is not None:
+                prop_metadata = generate_gridproperty_meta(
+                    restart_path, xtgeo_prop, "UNRST", config, xtgeoegrid
+                )
                 sumo_file = convert_xtgeo_2_sumo_file(
-                    restart_path, xtgeo_prop, "UNRST", config
+                    xtgeo_prop, prop_metadata
                 )
                 if sumo_file is None:
                     logger.warning(
@@ -217,9 +252,8 @@ def upload_simulation_run(datafile, config, dispatcher):
     grid_path = str(datafile_path.with_suffix(".EGRID"))
     egrid = Grid(grid_path)
     xtgeoegrid = grid_from_file(grid_path)
-    sumo_file = convert_xtgeo_2_sumo_file(
-        restart_path, xtgeoegrid, "grid", config
-    )
+    grid_metadata = generate_grid3d_meta(restart_path, xtgeoegrid, config)
+    sumo_file = convert_xtgeo_2_sumo_file(xtgeoegrid, grid_metadata)
     dispatcher.add(sumo_file)
     time_steps = get_timesteps(restart_path, egrid)
 

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -73,9 +73,9 @@ def generate_grid3d_meta(datafile, obj, config):
     relative_parent = str(Path(datafile).parents[2]).replace(
         str(Path(datafile).parents[4]), ""
     )
-    metadata["file"] = {
-        "relative_path": f"{relative_parent}/{tagname}--{name}".lower()
-    }
+    metadata["file"][
+        "relative_path"
+    ] = f"{relative_parent}/{tagname}--{name}".lower()
     assert isinstance(
         metadata, dict
     ), f"meta should be dict, but is {type(metadata)}"
@@ -116,9 +116,9 @@ def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
     relative_parent = str(Path(datafile).parents[2]).replace(
         str(Path(datafile).parents[4]), ""
     )
-    metadata["file"] = {
-        "relative_path": f"{relative_parent}/{tagname}--{name}".lower()
-    }
+    metadata["file"][
+        "relative_path"
+    ] = f"{relative_parent}/{tagname}--{name}".lower()
     assert isinstance(
         metadata, dict
     ), f"meta should be dict, but is {type(metadata)}"

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -175,7 +175,6 @@ def upload_init(init_path, xtgeoegrid, config, dispatcher, geometry_path):
             logger.warning("%s will not be exported", init_prop["name"])
             continue
         xtgeo_prop = make_xtgeo_prop(xtgeoegrid, init_prop)
-        xtgeo_prop.geometry = xtgeoegrid
         if xtgeo_prop is None:
             logger.warning("%s will not be uploaded", init_prop["name"])
             continue
@@ -219,7 +218,6 @@ def upload_restart(
                 continue
 
             xtgeo_prop = make_xtgeo_prop(xtgeoegrid, restart_prop)
-            xtgeo_prop.geometry = xtgeoegrid
             if xtgeo_prop is not None:
                 prop_metadata = generate_gridproperty_meta(
                     restart_path, xtgeo_prop, "UNRST", config, geometry_path

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -105,7 +105,7 @@ def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
         "name": name,
         "tagname": tagname,
         "content": {"property": {"is_discrete": False}},
-        "geometry": geogrid,
+        "geometry": geogrid.filesrc,
     }
     datefield = find_datefield(tagname)
     if datefield is not None:

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -80,11 +80,11 @@ def generate_grid3d_meta(datafile, obj, config):
     relative_parent = str(Path(datafile).parents[2]).replace(
         str(Path(datafile).parents[4]), ""
     )
-    print(f"GRID METADATA: {metadata}")
-    print(f"OUTGRID: {outgrid}")
     metadata["file"][
         "relative_path"
     ] = f"{relative_parent}/{tagname}--{name}".lower()
+    print(f"OUTGRID: {outgrid}")
+    print(f"GRID METADATA: {metadata}")
     assert isinstance(
         metadata, dict
     ), f"meta should be dict, but is {type(metadata)}"
@@ -262,6 +262,7 @@ def upload_simulation_run(datafile, config, dispatcher):
     Args:
         datafile (str): path to datafile
     """
+    print(f"UPLOADING GRID FOR DATAFILE: {datafile}")
     datafile_path = Path(datafile).resolve()
     init_path = str(datafile_path.with_suffix(".INIT"))
     restart_path = str(datafile_path.with_suffix(".UNRST"))

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -124,7 +124,7 @@ def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
     return metadata
 
 
-def convert_xtgeo_2_sumo_file(obj, metadata):
+def convert_xtgeo_to_sumo_file(obj, metadata):
     """Convert xtgeo object to SumoFile
 
     Args:
@@ -174,7 +174,7 @@ def upload_init(init_path, xtgeoegrid, config, dispatcher):
         prop_metadata = generate_gridproperty_meta(
             init_path, xtgeo_prop, "INIT", config, xtgeoegrid
         )
-        sumo_file = convert_xtgeo_2_sumo_file(xtgeo_prop, prop_metadata)
+        sumo_file = convert_xtgeo_to_sumo_file(xtgeo_prop, prop_metadata)
         if sumo_file is None:
             logger.warning(
                 "Property with name %s extracted from %s returned nothing",
@@ -213,7 +213,7 @@ def upload_restart(restart_path, xtgeoegrid, time_steps, config, dispatcher):
                 prop_metadata = generate_gridproperty_meta(
                     restart_path, xtgeo_prop, "UNRST", config, xtgeoegrid
                 )
-                sumo_file = convert_xtgeo_2_sumo_file(
+                sumo_file = convert_xtgeo_to_sumo_file(
                     xtgeo_prop, prop_metadata
                 )
                 if sumo_file is None:
@@ -253,7 +253,7 @@ def upload_simulation_run(datafile, config, dispatcher):
     egrid = Grid(grid_path)
     xtgeoegrid = grid_from_file(grid_path)
     grid_metadata = generate_grid3d_meta(restart_path, xtgeoegrid, config)
-    sumo_file = convert_xtgeo_2_sumo_file(xtgeoegrid, grid_metadata)
+    sumo_file = convert_xtgeo_to_sumo_file(xtgeoegrid, grid_metadata)
     dispatcher.add(sumo_file)
     time_steps = get_timesteps(restart_path, egrid)
 

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -80,8 +80,6 @@ def generate_grid3d_meta(datafile, obj, config):
     metadata["file"][
         "relative_path"
     ] = f"{relative_parent}/{tagname}--{name}".lower()
-    print(f"OUTGRID: {outgrid}")
-    print(f"GRID METADATA: {metadata}")
     assert isinstance(
         metadata, dict
     ), f"meta should be dict, but is {type(metadata)}"
@@ -125,7 +123,6 @@ def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
     metadata["file"][
         "relative_path"
     ] = f"{relative_parent}/{tagname}--{name}".lower()
-    print(f"GRIDPROP METADATA: {metadata}")
     assert isinstance(
         metadata, dict
     ), f"meta should be dict, but is {type(metadata)}"
@@ -260,7 +257,6 @@ def upload_simulation_run(datafile, config, dispatcher):
     Args:
         datafile (str): path to datafile
     """
-    print(f"UPLOADING GRID FOR DATAFILE: {datafile}")
     datafile_path = Path(datafile).resolve()
     init_path = str(datafile_path.with_suffix(".INIT"))
     restart_path = str(datafile_path.with_suffix(".UNRST"))
@@ -278,7 +274,6 @@ def upload_simulation_run(datafile, config, dispatcher):
     time_steps = get_timesteps(restart_path, egrid)
 
     # TODO: Delete the files written to disk after upload to Sumo is done
-
     upload_init(init_path, xtgeoegrid, config, dispatcher, grid_abs_path)
     upload_restart(
         restart_path, xtgeoegrid, time_steps, config, dispatcher, grid_abs_path

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -73,12 +73,15 @@ def generate_grid3d_meta(datafile, obj, config):
 
     exd = ExportData(**exp_args)
     metadata = exd.generate_metadata(obj)
+    outgrid = exd.export(obj)
+    print(f"OUTGRID: {outgrid}")
     relative_parent = str(Path(datafile).parents[2]).replace(
         str(Path(datafile).parents[4]), ""
     )
     metadata["file"][
         "relative_path"
     ] = f"{relative_parent}/{tagname}--{name}".lower()
+    print(f"METADATA FILE: {metadata['file']}")
     assert isinstance(
         metadata, dict
     ), f"meta should be dict, but is {type(metadata)}"
@@ -265,23 +268,18 @@ def upload_simulation_run(datafile, config, dispatcher):
     time_steps = get_timesteps(restart_path, egrid)
 
     grid_metadata_abs_path = grid_metadata["file"]["absolute_path"]
+    # TODO: Use dataio.export instead of NamedTempFile
+    # TODO: Delete the files written to disk after upload to Sumo is done
     # with namedtmpfile:
     #   write grid data to the tmp file
     #   use the tmp file to link geometry to grid properties
-    with NamedTemporaryFile(suffix=".yml", mode="w+t") as temp_file:
-        yaml.dump(grid_metadata, temp_file)
-        # temp_file.write(grid_metadata)
-        # temp_file.seek(0)
+    # with NamedTemporaryFile(suffix=".yml", mode="w+t") as temp_file:
+    #     yaml.dump(grid_metadata, temp_file)
+    #     # temp_file.write(grid_metadata)
+    #     # temp_file.seek(0)
 
-        upload_init(init_path, xtgeoegrid, config, dispatcher, temp_file.name)
-        upload_restart(
-            restart_path,
-            xtgeoegrid,
-            time_steps,
-            config,
-            dispatcher,
-            temp_file.name,
-        )
+    upload_init(init_path, xtgeoegrid, config, dispatcher)
+    upload_restart(restart_path, xtgeoegrid, time_steps, config, dispatcher)
 
 
 def get_timesteps(restart_path, egrid):

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -152,6 +152,7 @@ def convert_xtgeo_to_sumo_file(obj, metadata):
 
     bytestring = xtgeo_2_bytestring(obj)
 
+    # TODO: Why does FileOnJob set file.absolute_path to ""?
     sumo_file = FileOnJob(bytestring, metadata)
     sumo_file.path = metadata["file"]["relative_path"]
     sumo_file.metadata_path = ""
@@ -270,11 +271,15 @@ def upload_simulation_run(datafile, config, dispatcher):
     egrid = Grid(grid_path)
     xtgeoegrid = grid_from_file(grid_path)
     grid_metadata = generate_grid3d_meta(restart_path, xtgeoegrid, config)
+
+    # TODO: Have to get absolute_path here, because FileOnJob in convert_xtgeo_to_sumo_file
+    #       sets file.absolute_path to "".  Why?
+    grid_abs_path = grid_metadata["file"]["absolute_path"]
+
     sumo_file = convert_xtgeo_to_sumo_file(xtgeoegrid, grid_metadata)
     dispatcher.add(sumo_file)
     time_steps = get_timesteps(restart_path, egrid)
 
-    grid_abs_path = grid_metadata["file"]["absolute_path"]
     # TODO: Delete the files written to disk after upload to Sumo is done
 
     upload_init(init_path, xtgeoegrid, config, dispatcher, grid_abs_path)

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -105,7 +105,7 @@ def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
         "name": name,
         "tagname": tagname,
         "content": {"property": {"is_discrete": False}},
-        "geometry": geogrid.filesrc,
+        "geometry": geogrid,
     }
     datefield = find_datefield(tagname)
     if datefield is not None:

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -23,9 +23,6 @@ from fmu.sumo.uploader._fileonjob import FileOnJob
 
 from .common import find_datefield, give_name
 
-from tempfile import NamedTemporaryFile
-import yaml
-
 
 def xtgeo_2_bytestring(obj):
     """Convert xtgeo object to bytestring

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -101,7 +101,7 @@ def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
         obj (xtgeo object): the object to generate metadata on
         prefix (str): prefix to include
         config (dict): the fmu config file
-        geogrid (xtgeo grid): geometry to link to the grid property
+        geogrid (str): path to the grid to to link as geometry to the grid property
 
     Returns:
         dict: the metadata for obj
@@ -125,10 +125,10 @@ def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
     relative_parent = str(Path(datafile).parents[2]).replace(
         str(Path(datafile).parents[4]), ""
     )
-    print(f"GRIDPROP METADATA: {metadata}")
     metadata["file"][
         "relative_path"
     ] = f"{relative_parent}/{tagname}--{name}".lower()
+    print(f"GRIDPROP METADATA: {metadata}")
     assert isinstance(
         metadata, dict
     ), f"meta should be dict, but is {type(metadata)}"
@@ -317,6 +317,6 @@ def make_xtgeo_prop(xtgeoegrid, prop_dict):
         # prop_name has only one value. Will not return single value property."
         return None
 
-    xtgeo_prop = GridProperty(xtgeoegrid, name=prop_name)
+    xtgeo_prop = GridProperty(xtgeoegrid, name=prop_name, linkgeometry=True)
     xtgeo_prop.values = values
     return xtgeo_prop

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -6,8 +6,8 @@ Does three things:
 3. Uploads to Sumo
 """
 
-import os
 import logging
+import os
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -79,7 +79,6 @@ def generate_grid3d_meta(datafile, obj, config):
     outfile = exd.export(obj)
     datafile_path = Path(outfile)
     metadata_path = datafile_path.parent / f".{datafile_path.name}.yml"
-    print(f"METADATA PATH: {metadata_path}")
     metadata = yaml_load(metadata_path)
 
     relative_parent = str(Path(datafile).parents[2]).replace(
@@ -287,13 +286,11 @@ def upload_simulation_run(datafile, config, dispatcher):
 
     if os.path.exists(exported_grid_path):
         os.remove(exported_grid_path)
-        print(f"DELETED GRID FILE {exported_grid_path}")
     metadata_path = (
         exported_grid_path.parent / f".{exported_grid_path.name}.yml"
     )
     if os.path.exists(metadata_path):
         os.remove(metadata_path)
-        print(f"DELETED METADATA FILE {metadata_path}")
 
 
 def get_timesteps(restart_path, egrid):

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -73,11 +73,15 @@ def generate_grid3d_meta(datafile, obj, config):
 
     exd = ExportData(**exp_args)
     # TODO: Possible to only do .export() and get metadata from there?
+    #       export() calls generate_metadata() and puts it into a file.
+    #       Can just read that file instead of doing generate_metadata() again.
     metadata = exd.generate_metadata(obj)
     outgrid = exd.export(obj)
     relative_parent = str(Path(datafile).parents[2]).replace(
         str(Path(datafile).parents[4]), ""
     )
+    print(f"GRID METADATA: {metadata}")
+    print(f"OUTGRID: {outgrid}")
     metadata["file"][
         "relative_path"
     ] = f"{relative_parent}/{tagname}--{name}".lower()
@@ -121,6 +125,7 @@ def generate_gridproperty_meta(datafile, obj, prefix, config, geogrid):
     relative_parent = str(Path(datafile).parents[2]).replace(
         str(Path(datafile).parents[4]), ""
     )
+    print(f"GRIDPROP METADATA: {metadata}")
     metadata["file"][
         "relative_path"
     ] = f"{relative_parent}/{tagname}--{name}".lower()

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -53,9 +53,9 @@ def check_sumo(case_uuid, tag_prefix, correct, class_type, sumo):
     results = sumo.get(path, query).json()
 
     returned = results["hits"]["total"]["value"]
-    assert (
-        returned == check_nr
-    ), f"Supposed to upload {check_nr}, but actual were {returned}"
+    assert returned == check_nr, (
+        f"Supposed to upload {check_nr}, but actual were {returned}"
+    )
 
     sumo.delete(
         path,
@@ -72,12 +72,12 @@ def check_expected_exports(expected_exports, shared_grid, prefix):
     nr_parameter = len(parameters)
     nr_meta = len(meta)
     assert nr_parameter == nr_meta
-    assert (
-        nr_parameter == expected_exports
-    ), f"exported {nr_parameter} params, should be {expected_exports}"
-    assert (
-        nr_meta == expected_exports
-    ), f"exported {nr_meta} metadata objects, should be {expected_exports}"
+    assert nr_parameter == expected_exports, (
+        f"exported {nr_parameter} params, should be {expected_exports}"
+    )
+    assert nr_meta == expected_exports, (
+        f"exported {nr_meta} metadata objects, should be {expected_exports}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -89,9 +89,9 @@ def check_expected_exports(expected_exports, shared_grid, prefix):
 )
 def test_non_standard_filter_options(submod, options, expected):
     returned_options = filter_options(submod, options)
-    assert (
-        len(returned_options) > 0
-    ), f"No options left for {submod}, should be {expected}"
+    assert len(returned_options) > 0, (
+        f"No options left for {submod}, should be {expected}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -137,13 +137,13 @@ def test_create_config_dict(config, nrdatafiles, nrsubmodules, tmp_path):
     copytree(REEK_REAL1, real1)
     os.chdir(real1)
     inputs = create_config_dict(sim2sumo_config)
-    assert (
-        len(inputs) == nrdatafiles
-    ), f"{inputs.keys()} expected to have len {nrdatafiles} datafiles"
+    assert len(inputs) == nrdatafiles, (
+        f"{inputs.keys()} expected to have len {nrdatafiles} datafiles"
+    )
     for submod, subdict in inputs.items():
-        assert (
-            len(subdict) == nrsubmodules
-        ), f"{subdict} for {submod} expected to have {nrsubmodules} submodules"
+        assert len(subdict) == nrsubmodules, (
+            f"{subdict} for {submod} expected to have {nrsubmodules} submodules"
+        )
 
 
 def test_Dispatcher(case_uuid, token, scratch_files, monkeypatch):
@@ -180,9 +180,9 @@ def test_convert_xtgeo_to_sumo_file(
     sleep(SLEEP_TIME)
     obj = get_sumo_object(sumo, case_uuid, "FIPNUM", "EIGHTCELLS")
     prop = gridproperty_from_file(obj)
-    assert isinstance(
-        prop, GridProperty
-    ), f"obj should be xtgeo.GridProperty but is {type(prop)}"
+    assert isinstance(prop, GridProperty), (
+        f"obj should be xtgeo.GridProperty but is {type(prop)}"
+    )
     assert allclose(prop.values, eightfipnum.values)
     assert allequal(prop.values, eightfipnum.values)
 
@@ -201,9 +201,9 @@ def test_convert_table_2_sumo_file(
     sleep(SLEEP_TIME)
     obj = get_sumo_object(sumo, case_uuid, "EIGHTCELLS", "rft")
     table = pq.read_table(obj)
-    assert isinstance(
-        table, pa.Table
-    ), f"obj should be pa.Table but is {type(table)}"
+    assert isinstance(table, pa.Table), (
+        f"obj should be pa.Table but is {type(table)}"
+    )
     assert table == reekrft
     check_sumo(case_uuid, "rft", 1, "table", sumo)
 
@@ -314,17 +314,17 @@ def test_submodules_dict():
     assert isinstance(submods, dict)
     for submod_name, submod_dict in submods.items():
         assert isinstance(submod_name, str)
-        assert (
-            "/" not in submod_name
-        ), f"Left part of folder path for {submod_name}"
+        assert "/" not in submod_name, (
+            f"Left part of folder path for {submod_name}"
+        )
         assert isinstance(submod_dict, dict), f"{submod_name} has no subdict"
-        assert (
-            "options" in submod_dict
-        ), f"{submod_name} does not have any options"
+        assert "options" in submod_dict, (
+            f"{submod_name} does not have any options"
+        )
 
-        assert isinstance(
-            submod_dict["options"], tuple
-        ), f"options for {submod_name} not tuple"
+        assert isinstance(submod_dict["options"], tuple), (
+            f"options for {submod_name} not tuple"
+        )
 
 
 @pytest.mark.parametrize(
@@ -345,9 +345,9 @@ def test_get_table(submod):
         f" but returned {type(frame)}"
     )
     if submod == "summary":
-        assert (
-            frame.schema.field("FOPT").metadata is not None
-        ), "Metdata not carried across for summary"
+        assert frame.schema.field("FOPT").metadata is not None, (
+            "Metdata not carried across for summary"
+        )
 
 
 def test_convert_to_arrow():
@@ -369,9 +369,9 @@ def test_find_datafiles_reek(real, nrdfiles):
     os.chdir(real)
     datafiles = find_datafiles(None)
     expected_tools = ["eclipse", "opm", "ix", "pflotran"]
-    assert (
-        len(datafiles) == nrdfiles
-    ), f"Expected {nrdfiles} datafiles but found {len(datafiles)}"
+    assert len(datafiles) == nrdfiles, (
+        f"Expected {nrdfiles} datafiles but found {len(datafiles)}"
+    )
     for found_path in datafiles:
         parent = found_path.parent.parent.name
         assert parent in expected_tools, f"|{parent}| not in {expected_tools}"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -173,7 +173,7 @@ def test_convert_xtgeo_2_sumo_file(
 ):
     monkeypatch.chdir(scratch_files[0])
 
-    file = grid3d.convert_xtgeo_2_sumo_file(
+    file = grid3d.convert_xtgeo_to_sumo_file(
         scratch_files[1], eightfipnum, "INIT", config
     )
     sumo_conn = SumoConnection(env="dev", token=token)

--- a/tests/test_w_drogon.py
+++ b/tests/test_w_drogon.py
@@ -30,12 +30,12 @@ def test_vfp_to_arrow(options, keycombo, nrkeys, nrtables):
     for value in arrow_dict.values():
         nr_tables += len(value)
 
-    assert (
-        nr_tables == nrtables
-    ), f"Returned {nr_tables} tables, but should be {nrtables}"
-    assert set(arrow_dict.keys()) == set(
-        keycombo
-    ), f"Returned keys {arrow_dict.keys()}, should be {keycombo}"
+    assert nr_tables == nrtables, (
+        f"Returned {nr_tables} tables, but should be {nrtables}"
+    )
+    assert set(arrow_dict.keys()) == set(keycombo), (
+        f"Returned keys {arrow_dict.keys()}, should be {keycombo}"
+    )
 
 
 def test_vfp_tables_from_simulation_run(

--- a/tests/test_with_ert.py
+++ b/tests/test_with_ert.py
@@ -39,12 +39,12 @@ def write_ert_config_and_run(runpath):
         error_content = Path(runpath / "ERROR").read_text(encoding=encoding)
     except FileNotFoundError:
         error_content = ""
-    assert (
-        not error_content
-    ), f"ERROR file found with content:\n{error_content}"
-    assert Path(
-        runpath / "OK"
-    ).is_file(), f"running {ert_full_config_path}, No OK file"
+    assert not error_content, (
+        f"ERROR file found with content:\n{error_content}"
+    )
+    assert Path(runpath / "OK").is_file(), (
+        f"running {ert_full_config_path}, No OK file"
+    )
 
 
 def test_sim2sumo_with_ert(
@@ -80,6 +80,6 @@ def test_sim2sumo_with_ert(
     ).json()
 
     returned = results["hits"]["total"]["value"]
-    assert (
-        returned == expected_exports
-    ), f"Supposed to upload {expected_exports}, but actual were {returned}"
+    assert returned == expected_exports, (
+        f"Supposed to upload {expected_exports}, but actual were {returned}"
+    )


### PR DESCRIPTION
Closes #106 

* Separate methods for creating metadata for `grids` and `grid properties`
* Add `"geometry": grid` to the `ExportData` arguments when creating metadata for `grid properties`
    * This involves exporting the grid and its metadata to disk (dataio currently does not support "linking" geometry to a grid that is not on disk) The created files are deleted after upload to Sumo is done