### PR TITLE
chore: add sumo-uploader to dependency list

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -39,7 +39,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest
           python -m pip install pytest-timeout
-          python -m pip install .[all]
+          python -m pip install ".[all]"
       - name: Run tests
         shell: bash
         env:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -39,7 +39,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest
           python -m pip install pytest-timeout
-          python -m pip install .
+          python -m pip install .[all]
       - name: Run tests
         shell: bash
         env:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -37,9 +37,6 @@ jobs:
       - name: Install fmu-sumo-sim2sumo
         run: |
           python -m pip install --upgrade pip
-          python -m pip install opm
-          python -m pip install git+https://github.com/equinor/fmu-sumo-uploader.git@main
-          python -m pip install git+https://github.com/equinor/fmu-dataio.git@main
           python -m pip install pytest
           python -m pip install pytest-timeout
           python -m pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ test = ["pytest"]
 dev = ["pytest", "ruff", "pre-commit"]
 all = [
   "ert",
+  # Note: sim2sumo is dependent on fmu-sumo-uploader, but it is not installed by default.
+  #       The uploader version is specified by Komodo and sim2sumo should not override this.
   "fmu-sumo-uploader @ git+https://git@github.com/equinor/fmu-sumo-uploader",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "xtgeo",
   "pandas",
   "arrow",
+  "fmu-sumo-uploader @ git+https://git@github.com/equinor/fmu-sumo-uploader@main",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,15 @@ dependencies = [
   "xtgeo",
   "pandas",
   "arrow",
-  "fmu-sumo-uploader @ git+https://git@github.com/equinor/fmu-sumo-uploader@main",
 ]
 
 [project.optional-dependencies]
 test = ["pytest"]
 dev = ["pytest", "ruff", "pre-commit"]
-nokomodo = ["ert"]
+all = [
+  "ert",
+  "fmu-sumo-uploader @ git+https://git@github.com/equinor/fmu-sumo-uploader",
+]
 
 docs = [
   "sphinx==6.2.1",


### PR DESCRIPTION
Closes #117 

Sim2sumo is definitely dependent on sumo-uploader, but for historical purposes was not added as an installation dependency.
It still works for Komodo because the uploader is included in Komodo separately. (Note that in Komodo-releases Sumo-uploader is actually listed as a dependency)

Adding the dependency here as well for consistency.

(The reason that it was not included previously I believe was to enable installing sim2sumo outside of Komodo without too much other stuff, but don't think that really makes anymore)