### PR TITLE
fix: install required dependency on test runner

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
         os: [ubuntu-latest]
       max-parallel: 1
     permissions:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -34,6 +34,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # test_with_ert.py runs ert which uses PyQt6 which requires libegl1
+      - name: Install Ubuntu dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libegl1
+
       - name: Install fmu-sumo-sim2sumo
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -58,6 +58,7 @@ jobs:
           echo $sharedkey > ~/.sumo/88d2b022-3539-4dda-9e66-853801334a86.sharedkey
           ls -l ~/.sumo/88d2b022-3539-4dda-9e66-853801334a86.sharedkey
           pip list | grep sumo
+          export DEV_SCHEMA=1 # use fmu-dataio dev schema
           python -c  'import sys; print(sys.platform)'
           python -c 'import os; import sys; print(os.path.dirname(sys.executable))'
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
     os: ubuntu-22.04
     tools:
-        python: "3.10"
+        python: "3.11"
 
 python:
     install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 test = ["pytest"]
 dev = ["pytest", "ruff", "pre-commit"]
 all = [
-  "ert<14.0.1",
+  "ert",
   # Note: sim2sumo is dependent on fmu-sumo-uploader, but it is not installed by default.
   #       The uploader version is specified by Komodo and sim2sumo should not override this.
   "fmu-sumo-uploader @ git+https://git@github.com/equinor/fmu-sumo-uploader",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 test = ["pytest"]
 dev = ["pytest", "ruff", "pre-commit"]
 all = [
-  "ert",
+  "ert<14.0.0",
   # Note: sim2sumo is dependent on fmu-sumo-uploader, but it is not installed by default.
   #       The uploader version is specified by Komodo and sim2sumo should not override this.
   "fmu-sumo-uploader @ git+https://git@github.com/equinor/fmu-sumo-uploader",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 test = ["pytest"]
 dev = ["pytest", "ruff", "pre-commit"]
 all = [
-  "ert<14.0.0",
+  "ert>=14.0.0",
   # Note: sim2sumo is dependent on fmu-sumo-uploader, but it is not installed by default.
   #       The uploader version is specified by Komodo and sim2sumo should not override this.
   "fmu-sumo-uploader @ git+https://git@github.com/equinor/fmu-sumo-uploader",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fmu-sumo-sim2sumo"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
   "sumo-wrapper-python>=1.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 test = ["pytest"]
 dev = ["pytest", "ruff", "pre-commit"]
 all = [
-  "ert",
+  "ert<14.0.1",
   # Note: sim2sumo is dependent on fmu-sumo-uploader, but it is not installed by default.
   #       The uploader version is specified by Komodo and sim2sumo should not override this.
   "fmu-sumo-uploader @ git+https://git@github.com/equinor/fmu-sumo-uploader",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 test = ["pytest"]
 dev = ["pytest", "ruff", "pre-commit"]
 all = [
-  "ert>=14.0.0",
+  "ert",
   # Note: sim2sumo is dependent on fmu-sumo-uploader, but it is not installed by default.
   #       The uploader version is specified by Komodo and sim2sumo should not override this.
   "fmu-sumo-uploader @ git+https://git@github.com/equinor/fmu-sumo-uploader",


### PR DESCRIPTION
Closes #136 
`test_with_ert.py` is failing when using version `ert>=14.0.0` due to [this change](https://github.com/equinor/ert/pull/9860/files)
The introduction of `PyQt6` also requires `libegl1` to be installed.
For the existing tests to run, which we probably want, we need the test runner to have `libegl1` installed.

Closes #140 
Use `fmu-dataio` dev schema