### PR TITLE
feat: Add notify on Slack step to github workflow

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -7,7 +7,7 @@ on:
     - cron: "5 5 * * *"
 
 jobs:
-  build_pywheels:
+  run_tests:
     name: PY ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -65,17 +65,10 @@ jobs:
           pytest --log-cli-level=WARNING -s --timeout=300
 
       - name: Notify on Slack
-        if: ${{ github.event_name == 'pull_request' && failure() }}
+        if: ${{ github.event_name == 'schedule' && failure() }}
         uses: slackapi/slack-github-action@v2
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_RUAJ }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             text: "Sim2sumo nightly tests ${{ job.status }}. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
-
-        # text: "*GitHub Action build result*: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
-        # blocks:
-        #   - type: "section"
-        #     text:
-        #       type: "mrkdwn"
-        #       text: "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -59,6 +59,7 @@ jobs:
           ls -l ~/.sumo/88d2b022-3539-4dda-9e66-853801334a86.sharedkey
           pip list | grep sumo
           export DEV_SCHEMA=1 # use fmu-dataio dev schema
+
           python -c  'import sys; print(sys.platform)'
           python -c 'import os; import sys; print(os.path.dirname(sys.executable))'
 

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Run tests
         shell: bash
         env:
-          sharedkey: ${{ secrets.SHARED_KEY_DROGON_WRITE_DEV_2 }}
+          sharedkey: ${{ secrets.SHARED_KEY_DROGON_WRITE_DEV }}
         run: |
           az --version
           az account list

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -63,3 +63,19 @@ jobs:
           python -c 'import os; import sys; print(os.path.dirname(sys.executable))'
 
           pytest --log-cli-level=WARNING -s --timeout=300
+
+      - name: Notify on Slack
+        if: ${{ github.event_name == 'schedule' && failure() }}
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "Sim2sumo nightly tests failed."
+
+        # text: "*GitHub Action build result*: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+        # blocks:
+        #   - type: "section"
+        #     text:
+        #       type: "mrkdwn"
+        #       text: "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -65,13 +65,13 @@ jobs:
           pytest --log-cli-level=WARNING -s --timeout=300
 
       - name: Notify on Slack
-        if: ${{ github.event_name == 'schedule' && failure() }}
+        if: ${{ github.event_name == 'pull_request' && failure() }}
         uses: slackapi/slack-github-action@v2
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_RUAJ }}
           webhook-type: incoming-webhook
           payload: |
-            text: "Sim2sumo nightly tests failed."
+            text: "Sim2sumo nightly tests ${{ job.status }}. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
 
         # text: "*GitHub Action build result*: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
         # blocks:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Run tests
         shell: bash
         env:
-          sharedkey: ${{ secrets.SHARED_KEY_DROGON_WRITE_DEV }}
+          sharedkey: ${{ secrets.SHARED_KEY_DROGON_WRITE_DEV_2 }}
         run: |
           az --version
           az account list

--- a/tests/data/reek/realization-0/iter-0/share/results/tables/.2_r001_reek--rft.csv.yml
+++ b/tests/data/reek/realization-0/iter-0/share/results/tables/.2_r001_reek--rft.csv.yml
@@ -33,7 +33,7 @@ file:
 data:
   name: 2_R001_REEK
   stratigraphic: false
-  content: unset
+  content: depth
   tagname: rft
   format: csv
   layout: table

--- a/tests/data/reek/realization-0/iter-0/share/results/tables/.2_r001_reek--rft.csv.yml
+++ b/tests/data/reek/realization-0/iter-0/share/results/tables/.2_r001_reek--rft.csv.yml
@@ -1,5 +1,5 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.9.0/fmu_results.json
-version: 0.9.0
+$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.8.0/fmu_results.json
+version: 0.8.0
 source: fmu
 tracklog:
   - datetime: "2023-08-25T09:23:12.619916"

--- a/tests/data/reek/realization-0/iter-0/share/results/tables/.2_r001_reek--rft.csv.yml
+++ b/tests/data/reek/realization-0/iter-0/share/results/tables/.2_r001_reek--rft.csv.yml
@@ -1,5 +1,5 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.8.0/fmu_results.json
-version: 0.8.0
+$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.9.0/fmu_results.json
+version: 0.9.0
 source: fmu
 tracklog:
   - datetime: "2023-08-25T09:23:12.619916"

--- a/tests/data/reek/realization-0/iter-0/share/results/tables/.2_r001_reek--wellconnstatus.csv.yml
+++ b/tests/data/reek/realization-0/iter-0/share/results/tables/.2_r001_reek--wellconnstatus.csv.yml
@@ -33,7 +33,7 @@ file:
 data:
   name: 2_R001_REEK
   stratigraphic: false
-  content: unset
+  content: depth
   tagname: wellconnstatus
   format: csv
   layout: table

--- a/tests/data/reek/realization-0/iter-0/share/results/tables/.2_r001_reek--wellconnstatus.csv.yml
+++ b/tests/data/reek/realization-0/iter-0/share/results/tables/.2_r001_reek--wellconnstatus.csv.yml
@@ -1,5 +1,5 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.8.0/fmu_results.json
-version: 0.8.0
+$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.9.0/fmu_results.json
+version: 0.9.0
 source: fmu
 tracklog:
   - datetime: "2023-08-25T09:23:11.776770"

--- a/tests/data/reek/realization-0/iter-0/share/results/tables/.2_r001_reek--wellconnstatus.csv.yml
+++ b/tests/data/reek/realization-0/iter-0/share/results/tables/.2_r001_reek--wellconnstatus.csv.yml
@@ -1,5 +1,5 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.9.0/fmu_results.json
-version: 0.9.0
+$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.8.0/fmu_results.json
+version: 0.8.0
 source: fmu
 tracklog:
   - datetime: "2023-08-25T09:23:11.776770"

--- a/tests/data/reek/share/metadata/fmu_case.yml
+++ b/tests/data/reek/share/metadata/fmu_case.yml
@@ -1,5 +1,5 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.8.0/fmu_results.json
-version: 0.8.0
+$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.9.0/fmu_results.json
+version: 0.9.0
 source: fmu
 class: case
 masterdata:

--- a/tests/data/reek/share/metadata/fmu_case.yml
+++ b/tests/data/reek/share/metadata/fmu_case.yml
@@ -1,5 +1,5 @@
-$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.9.0/fmu_results.json
-version: 0.9.0
+$schema: https://main-fmu-schemas-dev.radix.equinor.com/schemas/0.8.0/fmu_results.json
+version: 0.8.0
 source: fmu
 class: case
 masterdata:


### PR DESCRIPTION
Related to https://github.com/equinor/fmu-sumo/issues/382

Sends message to "Sumo alerts" Slack channel if tests run during **scheduled nightly run**.
![image](https://github.com/user-attachments/assets/9656668a-3ae9-47af-879b-1df7dc19638d)

Message includes link to the logs for the failing run.

Needs https://github.com/equinor/fmu-sumo-sim2sumo/pull/137 for tests to pass.