### PR TITLE
fix: make datatypes=all return list of submodules (as intended)

### DIFF
--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -136,7 +136,7 @@ def create_config_dict(config):
 
     if datatype is None:
         default_submods = ["summary", "rft", "satfunc"]
-    elif datatype == "all":
+    elif "all" in datatype:
         default_submods = SUBMODULES
     elif isinstance(datatype, list):
         default_submods = datatype


### PR DESCRIPTION
Small bug fix. Tested on JS model.