### PR TITLE
fix: correct dependency on pyarrow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "res2df",
   "xtgeo",
   "pandas",
-  "arrow",
+  "pyarrow",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`arrow` is not the correct dependency for handling arrow files, it handles date/time formatting https://snyk.io/advisor/python/arrow.

Fix to have the correct dependency on `pyarrow`