### PR TITLE
fix: always check if slack notification should be sent

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -66,7 +66,7 @@ jobs:
           pytest --log-cli-level=WARNING -s --timeout=300
 
       - name: Notify on Slack
-        if: ${{ github.event_name == 'schedule' && failure() }}
+        if: ${{ always() && github.event_name == 'schedule' && failure() }}
         uses: slackapi/slack-github-action@v2
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Add always() to notification step to always evaluate if notification should be sent.