### PR TITLE
fix: check grid datatype specified

### DIFF
--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -274,7 +274,7 @@ def upload_simulation_runs(datafiles, config, dispatcher):
         dispatcher (sim2sumo.common.Dispatcher)
     """
     for datafile in datafiles:
-        if not datafiles[datafile]["grid"]:
+        if "grid" not in datafiles[datafile]:
             continue
         upload_simulation_run(datafile, config, dispatcher)
 


### PR DESCRIPTION
Previously, `grid` was always added as a boolean.
Now, `grid` is added if it should be used (as any other datatype). Therefore have to check if it is present at all.