### PR TITLE
fix: Get grid 'name' metadata from simulation data file name

### DIFF
--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -67,7 +67,6 @@ def generate_grid3d_meta(datafile, obj, config):
         "content": "depth",
     }
 
-
     # Future: refactor to be "diskless"
     #   i.e. use exd.generate_metadata() instead of exd.export()
     #       metadata = exd.generate_metadata(obj)


### PR DESCRIPTION
See #155 

Small update to grid & grid properties metadata.

- Grid `data["name"]` = data file name
- Grid properties `data["geometry"]["name"]`  = data file name