### PR TITLE
fix: assert sumo_env is valid in forward model

### DIFF
--- a/src/fmu/sumo/sim2sumo/forward_models/__init__.py
+++ b/src/fmu/sumo/sim2sumo/forward_models/__init__.py
@@ -36,6 +36,10 @@ class Sim2Sumo(ForwardModelStepPlugin):
         self, fm_step_json: ForwardModelStepJSON
     ) -> None:
         env = os.environ.get("SUMO_ENV", "prod")
+        if env not in ["preview", "dev", "test", "prod"]:
+            raise ForwardModelStepValidationError(
+                f"Invalid value for environment variable 'SUMO_ENV': {env}. Valid values are preview, dev, test and prod."
+            )
         command = f"sumo_login -e {env} -m silent"
         return_code = subprocess.call(command, shell=True)
 


### PR DESCRIPTION
Assert `env` is safe since it is passed to `subprocess.call`

Should handle possible vulnerability reported by Snyk: https://equinor.slack.com/archives/C082ZC6FPA6/p1758274928016149