### PR TITLE
fix: refine error message for pre experiment validation

### DIFF
--- a/src/fmu/sumo/sim2sumo/forward_models/__init__.py
+++ b/src/fmu/sumo/sim2sumo/forward_models/__init__.py
@@ -44,9 +44,10 @@ class Sim2Sumo(ForwardModelStepPlugin):
         return_code = subprocess.call(command, shell=True)
 
         err_msg = (
-            "Your config uses Sumo, please authenticate"
-            " by running the following in your terminal:"
-            f" sumo_login{f' -e {env}' if env != 'prod' else ''}"
+            f"Your config uses Sumo. Detected environment varibale 'SUMO_ENV': {env}\n"
+            "- If the value of `SUMO_ENV` is as expected, please run the following in your terminal:"
+            f" sumo_login{f' -e {env}' if env != 'prod' else ''}\n"
+            f"- If the value is not correct, set `SUMO_ENV` to your desired environment in your terminal. Valid values are preview, dev, test and prod."
         )
 
         if return_code != 0:


### PR DESCRIPTION
Linked issue https://github.com/equinor/fmu-sumo-uploader/issues/167

-  Refined error message in pre experiment validation, especially for a workflow failed due to trying to upload to dev without setting SUMO_ENV to dev.