### PR TITLE
feat: delegate global config loading to fmu-dataio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
   "sumo-wrapper-python>=1.0.24",
-  "fmu-dataio>=2.24.0",
+  "fmu-dataio>=2.26.0",
   "fmu-datamodels",
   "opm>=2020.10.2",
   "res2df",
@@ -19,7 +19,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest"]
+test = ["pytest", "fmu-settings"]
 dev = ["pytest", "ruff", "pre-commit"]
 all = [
   "ert",

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -121,7 +121,7 @@ class Dispatcher:
     def __init__(
         self,
         datafile,
-        env: Literal["dev", "prod"],
+        env: Literal["dev", "test", "preview", "prod"],
         config_path: str | Path = Path(
             "fmuconfig/output/global_variables.yml"
         ),
@@ -215,7 +215,7 @@ def nodisk_upload(
     files: list[Any],
     parent_id: str,
     config_path: Path,
-    env: Literal["dev", "prod"] = "prod",
+    env: Literal["dev", "test", "preview", "prod"] = "prod",
     connection=None,
 ) -> None:
     """Upload files to sumo

--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -3,16 +3,12 @@
 import logging
 import re
 from pathlib import Path
+from typing import Any, Literal
 
 import psutil
 import yaml
 from sumo.wrapper import SumoClient
 
-from fmu.sumo.sim2sumo._special_treatments import (
-    DEFAULT_RST_PROPS,
-    DEFAULT_SUBMODULES,
-    SUBMODULES,
-)
 from fmu.sumo.uploader._upload_files import upload_files
 
 
@@ -119,86 +115,16 @@ def find_datafiles(seedpoint=None):
     return unique_datafiles
 
 
-def create_config_dict(config):
-    """Read config settings and make dictionary for use when exporting.
-
-    Args:
-        config (dict): FMU global variables file created by
-                       fmu-config(https://github.com/equinor/fmu-config).
-
-    Returns:
-        dict: A dictionary consists of fmuconfig with metadata and sim2sumoconfig.
-              sim2sumoconfig is a dictionary with key as path to datafile,
-              value as dict of submodule and option.
-    """
-    simconfig = config.get("sim2sumo", {})
-    validate_sim2sumo_config(simconfig)
-
-    # Use the provided datafile or datatype if given, otherwise use simconfig
-    datafile = simconfig.get("datafile", None)
-    datatype = simconfig.get("datatypes", None)
-
-    if datatype is None:
-        default_submods = DEFAULT_SUBMODULES
-    elif "all" in datatype:
-        default_submods = SUBMODULES
-    elif isinstance(datatype, list):
-        default_submods = datatype
-    else:
-        default_submods = [datatype]
-
-    submods = default_submods
-
-    paths = []
-    if datafile:
-        for file in datafile:
-            if isinstance(file, dict):
-                (((filepath, file_submods)),) = file.items()
-                submods = file_submods or default_submods
-            else:
-                filepath = file
-
-            path = Path(filepath)
-            if path.is_file():
-                paths += [path]
-            else:
-                paths += find_datafiles(path)
-    else:
-        paths += find_datafiles(None)
-
-    # Initialize the dictionary to hold the configuration for each datafile
-    sim2sumoconfig = {}
-    for datafile_path in paths:
-        sim2sumoconfig[datafile_path] = {}
-        for submod in submods:
-            sim2sumoconfig[datafile_path][submod] = {"arrow": True}
-
-            # Restart properties config
-            if submod == "grid":
-                # Get rstprops config if it is provided
-                rstprops = simconfig.get("rstprops", None)
-
-                if rstprops:
-                    sim2sumoconfig[datafile_path][submod]["rstprops"] = [
-                        x.upper() for x in rstprops
-                    ]
-                else:
-                    sim2sumoconfig[datafile_path][submod]["rstprops"] = (
-                        DEFAULT_RST_PROPS
-                    )
-
-    # Return the dictionary that holds both fmu and sim2sumo config
-    return {"fmuconfig": config, "sim2sumoconfig": sim2sumoconfig}
-
-
 class Dispatcher:
     """Controls upload to sumo"""
 
     def __init__(
         self,
         datafile,
-        env,
-        config_path="fmuconfig/output/global_variables.yml",
+        env: Literal["dev", "prod"],
+        config_path: str | Path = Path(
+            "fmuconfig/output/global_variables.yml"
+        ),
         token=None,
     ):
         self._logger = logging.getLogger(__name__ + ".Dispatcher")
@@ -208,7 +134,7 @@ class Dispatcher:
         self._mem_limit = (
             psutil.virtual_memory().available * self._limit_percent
         )
-        self._config_path = config_path
+        self._config_path = Path(config_path)
 
         self._mem_count = 0
         self._count = 0
@@ -285,27 +211,39 @@ def find_datefield(text_string):
     return date
 
 
-def nodisk_upload(files, parent_id, config_path, env="prod", connection=None):
+def nodisk_upload(
+    files: list[Any],
+    parent_id: str,
+    config_path: Path,
+    env: Literal["dev", "prod"] = "prod",
+    connection=None,
+) -> None:
     """Upload files to sumo
 
     Args:
-        files (list): should contain only SumoFile objects
-        parent_id (str): uuid of parent object
-        connection (str): client to upload with
+        files: list of SumoFile objects
+        parent_id: uuid of parent object
+        config_path: Path to global configuration
+        env: Sumo env
+        connection: client to upload with
     """
     logger = logging.getLogger(__name__ + ".nodisk_upload")
-    if len(files) > 0:
-        logger.info("Uploading %s files to parent %s", len(files), parent_id)
-        if connection is None:
-            connection = SumoClient(env=env, case_uuid=parent_id)
-        status = upload_files(
-            files, parent_id, connection, config_path=config_path
-        )
-        print("Status after upload: ", end="\n--------------\n")
-        for state, obj_status in status.items():
-            print(f"{state}: {len(obj_status)}")
-    else:
+
+    if len(files) == 0:
         logger.info("No passed files, nothing to do here")
+        return
+
+    logger.info("Uploading %s files to parent %s", len(files), parent_id)
+    if connection is None:
+        connection = SumoClient(env=env, case_uuid=parent_id)
+
+    status = upload_files(
+        files, parent_id, connection, config_path=str(config_path)
+    )
+
+    print("Status after upload: ", end="\n--------------\n")
+    for state, obj_status in status.items():
+        print(f"{state}: {len(obj_status)}")
 
 
 def give_name(datafile_path: str) -> str:

--- a/src/fmu/sumo/sim2sumo/config.py
+++ b/src/fmu/sumo/sim2sumo/config.py
@@ -1,0 +1,144 @@
+"""Configuration container and builder for sim2sumo."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Self
+
+from fmu.dataio._global_config import load_global_config
+from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
+from fmu.sumo.sim2sumo._special_treatments import (
+    DEFAULT_RST_PROPS,
+    DEFAULT_SUBMODULES,
+    SUBMODULES,
+)
+from fmu.sumo.sim2sumo.common import (
+    find_datafiles,
+    validate_sim2sumo_config,
+    yaml_load,
+)
+
+
+@dataclass
+class Sim2SumoConfig:
+    """Configuration container for sim2sumo.
+
+    Attributes:
+        global_config: Validated FMU global configuration from fmu-dataio.
+        sim2sumo: Per-datafile mapping of submodules to their options.
+    """
+
+    global_config: GlobalConfiguration
+    sim2sumo: dict[Path, dict[str, dict[str, Any]]] = field(
+        default_factory=dict
+    )
+
+    @classmethod
+    def from_global_variables(
+        cls, config_path: Path | str | None = None
+    ) -> Self:
+        """Build a Sim2SumoConfig from a global_variables.yml path.
+
+        The FMU global configuration is loaded via
+        ``fmu.dataio._global_config.load_global_config`` which first checks for
+        a ``.fmu/`` directory and then falls back to the YAML file at
+        *config_path*.  The ``sim2sumo`` section is read from the same YAML
+        file (it is not part of the GlobalConfiguration model).
+
+        Args:
+            config_path: Path to ``global_variables.yml``.  When *None*,
+                ``load_global_config`` will search in the standard locations.
+
+        Returns:
+            A fully resolved :class:`Sim2SumoConfig`.
+        """
+        resolved_path = Path(config_path) if config_path is not None else None
+        global_config = load_global_config(resolved_path)
+
+        # The sim2sumo section lives in the same YAML but is not part of
+        # GlobalConfiguration. We need to load the raw YAML to get it.
+        raw: dict[str, Any] = {}
+        if resolved_path is not None:
+            raw = yaml_load(resolved_path)
+        else:
+            # Try the standard location used by load_global_config
+            for candidate in [
+                Path("fmuconfig/output/global_variables.yml"),
+                Path("../../fmuconfig/output/global_variables.yml"),
+            ]:
+                if candidate.is_file():
+                    raw = yaml_load(candidate)
+                    break
+
+        simconfig = raw.get("sim2sumo", {})
+        sim2sumo_config = _build_sim2sumo_config(simconfig)
+
+        return cls(
+            global_config=global_config,
+            sim2sumo=sim2sumo_config,
+        )
+
+
+def _build_sim2sumo_config(
+    simconfig: dict[str, Any],
+) -> dict[Path, dict[str, dict[str, Any]]]:
+    """Resolve datafiles and build the per-file submodule config mappings.
+
+    Args:
+        simconfig: The ``sim2sumo`` section from the raw YAML config.
+
+    Returns:
+        Mapping of datafile paths to their submodule config dicts.
+    """
+    validate_sim2sumo_config(simconfig)
+
+    datafile = simconfig.get("datafile")
+    datatype = simconfig.get("datatypes")
+
+    if datatype is None:
+        default_submods = DEFAULT_SUBMODULES
+    elif "all" in datatype:
+        default_submods = SUBMODULES
+    elif isinstance(datatype, list):
+        default_submods = datatype
+    else:
+        default_submods = [datatype]
+
+    submods = default_submods
+
+    paths: list[Path] = []
+    if datafile:
+        for file in datafile:
+            if isinstance(file, dict):
+                (((filepath, file_submods)),) = file.items()
+                submods = file_submods or default_submods
+            else:
+                filepath = file
+
+            path = Path(filepath)
+            if path.is_file():
+                paths.append(path)
+            else:
+                paths.extend(find_datafiles(path))
+    else:
+        paths.extend(find_datafiles(None))
+
+    sim2sumoconfig: dict[Path, dict[str, dict[str, Any]]] = {}
+    for datafile_path in paths:
+        sim2sumoconfig[datafile_path] = {}
+        for submod in submods:
+            sim2sumoconfig[datafile_path][submod] = {"arrow": True}
+
+            # Restart properties config
+            if submod == "grid":
+                # Get rstprops config if it is provided
+                rstprops = simconfig.get("rstprops")
+                if rstprops:
+                    sim2sumoconfig[datafile_path][submod]["rstprops"] = [
+                        x.upper() for x in rstprops
+                    ]
+                else:
+                    sim2sumoconfig[datafile_path][submod]["rstprops"] = (
+                        DEFAULT_RST_PROPS
+                    )
+
+    return sim2sumoconfig

--- a/src/fmu/sumo/sim2sumo/grid3d.py
+++ b/src/fmu/sumo/sim2sumo/grid3d.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Upload grid3d data from reservoir simulators to Sumo
+
 Does three things:
 1. Extracts data from simulator to roff files
 2. Adds the required metadata while exporting to disc
@@ -12,10 +13,12 @@ import re
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from resdata.grid import Grid
 from resdata.resfile import ResdataRestartFile
+import xtgeo
 from xtgeo import GridProperty, grid_from_file
 from xtgeo.grid3d import _gridprop_import_eclrun as eclrun
 from xtgeo.io._file import FileWrapper
@@ -23,8 +26,9 @@ from xtgeo.io._file import FileWrapper
 from fmu.dataio import ExportData
 from fmu.sumo.uploader._fileonjob import FileOnJob
 
-from .common import find_datefield, give_name, yaml_load
 from ._units import get_all_properties_units, get_datafile_unit_system
+from .common import find_datefield, give_name, yaml_load
+from .config import Sim2SumoConfig
 
 
 def xtgeo_2_bytestring(obj):
@@ -48,21 +52,22 @@ def xtgeo_2_bytestring(obj):
 
 # Almost equal to tables.py::generate_table_meta,
 # difference in name and tagname
-def generate_grid3d_meta(datafile, obj, config):
-    """Generate metadata for xtgeo object
+def generate_grid3d_meta(
+    datafile: str | Path, obj: xtgeo.Grid, config: Sim2SumoConfig
+) -> dict[str, Any]:
+    """Generate metadata for an xtgeo grid object.
 
     Args:
-        datafile (str): path to datafile
-        obj (xtgeo object): the object to generate metadata on
-        config (dict): the fmuconfig with metadata and sim2sumoconfig
+        datafile: path to datafile
+        obj: xtgeo grid object
+        config: sim2sumo configuration
 
     Returns:
-        dict: the metadata for obj
+        Metadata dict for *obj*.
     """
-
     tagname = give_name(datafile)
-    exp_args = {
-        "config": config["fmuconfig"],
+    exp_args: dict[str, Any] = {
+        "config": config.global_config,
         "name": give_name(datafile),
         "tagname": tagname,
         "content": "depth",
@@ -88,23 +93,28 @@ def generate_grid3d_meta(datafile, obj, config):
     return metadata
 
 
-def generate_gridproperty_meta(datafile, obj, property_units, config, geogrid):
-    """Generate metadata for xtgeo object
+def generate_gridproperty_meta(
+    datafile: str | Path,
+    obj: xtgeo.GridProperty,
+    property_units: dict[str, str | None],
+    config: Sim2SumoConfig,
+    geogrid: str | Path,
+) -> dict[str, Any]:
+    """Generate metadata for an xtgeo grid property.
 
     Args:
-        datafile (str): path to datafile
-        obj (xtgeo object): the object to generate metadata on
-        property_units (dict): property - unit map
-        config (dict): the fmuconfig with metadata and sim2sumoconfig
-        geogrid (str): path to the grid to link as geometry
+        datafile: path to datafile
+        obj: xtgeo GridProperty object
+        property_units: property-to-unit mapping
+        config: sim2sumo configuration
+        geogrid: path to the grid to link as geometry
 
     Returns:
-        dict: the metadata for obj
+        Metadata dict for *obj*.
     """
-
     tagname = give_name(datafile)
-    exp_args = {
-        "config": config["fmuconfig"],
+    exp_args: dict[str, Any] = {
+        "config": config.global_config,
         "tagname": tagname,
         "content": "property",
         "content_metadata": {"is_discrete": False},
@@ -119,7 +129,7 @@ def generate_gridproperty_meta(datafile, obj, property_units, config, geogrid):
     # which has the format "PROPERTY-DATE".
     # The name has to be santised after find_datafield().
     exp_args["name"] = sanitise_gridprop_name(obj.name)
-    exp_args["unit"] = property_units.get(exp_args["name"], None)
+    exp_args["unit"] = property_units.get(exp_args["name"])
 
     exd = ExportData(**exp_args)
 
@@ -230,8 +240,13 @@ def get_restart_properties(restart_path, xtgeoegrid, datafileconfig) -> list:
 
 
 def upload_init(
-    init_path, xtgeoegrid, property_units, config, dispatcher, geometry_path
-):
+    init_path: str,
+    xtgeoegrid: Any,
+    property_units: dict[str, str | None],
+    config: Sim2SumoConfig,
+    dispatcher: Any,
+    geometry_path: str | Path,
+) -> None:
     """Upload properties from init file
 
     Args:
@@ -269,15 +284,15 @@ def upload_init(
 
 
 def upload_restart(
-    restart_path,
-    xtgeoegrid,
-    property_units,
-    time_steps,
-    config,
-    datafile,
-    dispatcher,
-    geometry_path,
-):
+    restart_path: str,
+    xtgeoegrid: Any,
+    property_units: dict[str, str | None],
+    time_steps: list[str],
+    config: Sim2SumoConfig,
+    datafile: Path,
+    dispatcher: Any,
+    geometry_path: str | Path,
+) -> None:
     """Export properties from restart file
 
     Args:
@@ -285,14 +300,13 @@ def upload_restart(
         xtgeoegrid (xtgeo.Grid): the grid to unpack the properties to
         time_steps (list): the timesteps to use
         config (dict): the fmuconfig file with metadata and sim2sumoconfig
-
     Returns:
         int: number of objects to export
     """
     logger = logging.getLogger(__name__ + ".upload_restart")
 
     prop_names = get_restart_properties(
-        restart_path, xtgeoegrid, config["sim2sumoconfig"][datafile]
+        restart_path, xtgeoegrid, config.sim2sumo[datafile]
     )
 
     for prop_name in prop_names:
@@ -328,20 +342,22 @@ def upload_restart(
                 dispatcher.add(sumo_file)
 
 
-def upload_simulation_runs(config, dispatcher):
+def upload_simulation_runs(config: Sim2SumoConfig, dispatcher: Any) -> None:
     """Upload 3d grid and parameters for set of simulation runs
 
     Args:
         config (dict): the fmuconfig file with metadata and sim2sumoconfig
         dispatcher (sim2sumo.common.Dispatcher)
     """
-    for datafile in config["sim2sumoconfig"]:
-        if "grid" not in config["sim2sumoconfig"][datafile]:
+    for datafile in config.sim2sumo:
+        if "grid" not in config.sim2sumo[datafile]:
             continue
         upload_simulation_run(datafile, config, dispatcher)
 
 
-def upload_simulation_run(datafile, config, dispatcher):
+def upload_simulation_run(
+    datafile: Path, config: Sim2SumoConfig, dispatcher: Any
+) -> None:
     """Export 3d grid properties from simulation run
 
     Args:

--- a/src/fmu/sumo/sim2sumo/main.py
+++ b/src/fmu/sumo/sim2sumo/main.py
@@ -4,13 +4,15 @@ import argparse
 import logging
 import sys
 from os import environ
+from pathlib import Path
 
-from .common import Dispatcher, create_config_dict, yaml_load
+from .common import Dispatcher
+from .config import Sim2SumoConfig
 from .grid3d import upload_simulation_runs
 from .tables import upload_tables
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     """Parse arguments for command line tool
 
     Returns:
@@ -44,7 +46,7 @@ def parse_args():
 
 # e.g. _ERT_RUNPATH = ../realization-0/iter-0
 # e.g. _ERT_EXPERIMENT_ID = <uuid>
-# e.g. __ERT_SIMULATION_MODE = ensemble_experiment
+# e.g. _ERT_SIMULATION_MODE = ensemble_experiment
 # fmu-dataio needs these when creating metadata
 REQUIRED_ENV_VARS = [
     "_ERT_EXPERIMENT_ID",
@@ -57,11 +59,7 @@ def main():
     """Main function to be called"""
     logger = logging.getLogger(__file__ + ".main")
 
-    missing = []
-    for env_var in REQUIRED_ENV_VARS:
-        if env_var not in environ:
-            missing.append(env_var)
-
+    missing = [v for v in REQUIRED_ENV_VARS if v not in environ]
     if missing:
         print(
             "Required ERT environment variables not found:"
@@ -72,23 +70,21 @@ def main():
         sys.exit()
 
     args = parse_args()
+    config_path = Path(args.config_path)
 
-    fmu_config = yaml_load(args.config_path)
-    fmu_config["file_path"] = args.config_path
     try:
-        config = create_config_dict(fmu_config)
-        if not config.get("sim2sumoconfig"):
+        config = Sim2SumoConfig.from_global_variables(config_path)
+        if not config.sim2sumo:
             raise Exception("Found no files to upload")
     except Exception as e:
-        logger.error("Failed to create config dict: %s", e)
+        logger.error("Failed to create config: %s", e)
         return
+
     # Init of dispatcher needs one datafile to locate case uuid
-    one_datafile = list(config.get("sim2sumoconfig").keys())[0]
+    one_datafile = next(iter(config.sim2sumo))
     env = environ.get("SUMO_ENV", "prod")
     try:
-        dispatcher = Dispatcher(
-            one_datafile, env, config_path=args.config_path
-        )
+        dispatcher = Dispatcher(one_datafile, env, config_path=config_path)
     except Exception as e:
         logger.error("Failed to create dispatcher: %s", e)
         return

--- a/src/fmu/sumo/sim2sumo/tables.py
+++ b/src/fmu/sumo/sim2sumo/tables.py
@@ -1,4 +1,5 @@
 """Upload tabular data from reservoir simulators to sumo
+
 Does three things:
 1. Extracts data from simulator to arrow files
 2. Adds the required metadata while exporting to disc
@@ -12,6 +13,7 @@ import logging
 import sys
 from copy import deepcopy
 from itertools import islice
+from pathlib import Path
 from typing import Any, Union
 
 import pandas as pd
@@ -32,6 +34,7 @@ from ._special_treatments import (
     vfp_to_arrow_dict,
 )
 from .common import find_datefield, give_name
+from .config import Sim2SumoConfig
 from .version import version
 
 # map of res2df modules to fmu.datamodels content
@@ -74,23 +77,22 @@ def table_2_bytestring(table):
     return bytestring
 
 
-# Almost equal to grid3d.py::generate_grid3d_meta, but note difference in name and tagname
 def generate_table_meta(
-    datafile: str,
+    datafile: str | Path,
     table: pa.Table | pd.DataFrame,
     tagname: str,
-    config: dict[str, Any],
+    config: Sim2SumoConfig,
 ) -> dict[str, Any]:
-    """Generate metadata for xtgeo object
+    """Generate metadata for a table object.
 
     Args:
-        datafile: path to datafile
-        table: the object to generate metadata on
-        tagname: tagname
-        config: the fmuconfig with metadata and sim2sumoconfig
+        datafile: path to the simulator datafile
+        table: the table to generate metadata for
+        tagname: submodule tag
+        config: sim2sumo configuration
 
     Returns:
-        Dictionary of metadata for the table
+        Metadata dict for *obj*.
     """
     if "vfp" in tagname.lower():
         content = "lift_curves"
@@ -99,8 +101,8 @@ def generate_table_meta(
 
     name = give_name(datafile)
 
-    exp_args = {
-        "config": config["fmuconfig"],
+    exp_args: dict[str, Any] = {
+        "config": config.global_config,
         "name": name,
         "tagname": tagname,
         "content": content,
@@ -122,20 +124,26 @@ def generate_table_meta(
     return generate_metadata(export_config, table)
 
 
-def convert_table_2_sumo_file(datafile, obj, tagname, config):
-    """Convert table to Sumo File ready for shipping to sumo
+def convert_table_2_sumo_file(
+    datafile: str | Path,
+    obj: pa.Table | pd.DataFrame | None,
+    tagname: str,
+    config: Sim2SumoConfig,
+) -> list[FileOnJob] | None:
+    """Convert table to Sumo File ready for shipping to sumo.
+
     If the table is a summary table and has a defined table_index
-        we also return the table in chunks of 500 columns with
-        _sumo.hidden set to True
+    we also return the table in chunks of 500 columns with
+    ``_sumo.hidden`` set to True.
 
     Args:
-      datafile (str|PosixPath): path to datafile connected to extracted object
-      obj (pa.Table): The object to prepare for upload
-      tagname (str): what submodule the table is extracted from
-      config (dict): the fmuconfig with metadata and sim2sumoconfig
+      datafile: path to datafile connected to extracted object
+      obj: the table to prepare for upload
+      tagname: what submodule the table is extracted from
+      config: sim2sumo configuration
+
     Returns:
-      files (list): List of SumoFile objects with table object
-        as bytestring and metadata as dictionary
+      List of SumoFile objects, or *None* when *obj* is None.
     """
     if obj is None:
         return obj
@@ -257,14 +265,14 @@ def get_table(
     return output
 
 
-def upload_tables(config, dispatcher):
-    """Upload tables to sumo
+def upload_tables(config: Sim2SumoConfig, dispatcher: Any) -> None:
+    """Upload tables to sumo.
 
     Args:
-        config (dict): the fmuconfig with metadata and the sim2sumoconfig
-        env (str): what environment to upload to
+        config: sim2sumo configuration
+        dispatcher: upload dispatcher
     """
-    for datafile_path, submod_and_options in config["sim2sumoconfig"].items():
+    for datafile_path, submod_and_options in config.sim2sumo.items():
         datafile_path = datafile_path.resolve()
         upload_tables_from_simulation_run(
             datafile_path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from sumo.wrapper import SumoClient
 from xtgeo import grid_from_file, gridproperty_from_file
 
 from fmu.sumo.sim2sumo._special_treatments import convert_to_arrow
-from fmu.sumo.sim2sumo.common import create_config_dict
+from fmu.sumo.sim2sumo.config import Sim2SumoConfig
 
 REEK_ROOT = Path(__file__).parent / "data/reek"
 REEK_REAL0 = REEK_ROOT / "realization-0/iter-0/"
@@ -37,11 +37,10 @@ def set_up_tmp(path):
     grid_path = str(eight_datafile).replace(".DATA", ".EGRID")
     grid = grid_from_file(grid_path)
 
-    fmu_config = yaml_load(config_path)
-    config = create_config_dict(fmu_config)
+    config = Sim2SumoConfig.from_global_variables(config_path)
 
     exp_args = {
-        "config": config["fmuconfig"],
+        "config": config.global_config,
         "name": "",
         "tagname": "",
         "content": "depth",
@@ -99,7 +98,7 @@ def _fix_config():
 @pytest.fixture(name="s2s_config")
 def _fix_s2s_config(scratch_files, monkeypatch):
     monkeypatch.chdir(scratch_files[0])
-    return create_config_dict(yaml_load(CONFIG_PATH))
+    return Sim2SumoConfig.from_global_variables(CONFIG_PATH)
 
 
 @pytest.fixture(scope="session", name="sumo")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,130 @@
+"""Tests for fmu.sumo.sim2sumo.config."""
+
+from shutil import copytree
+
+import pytest
+from conftest import CONFIG_PATH, REEK_REAL1
+from fmu.dataio import ExportData
+from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
+
+from fmu.sumo.sim2sumo._special_treatments import (
+    DEFAULT_RST_PROPS,
+    DEFAULT_SUBMODULES,
+)
+from fmu.sumo.sim2sumo.config import Sim2SumoConfig, _build_sim2sumo_config
+
+NR_DEFAULT_SUBMODULES = len(DEFAULT_SUBMODULES)
+
+
+@pytest.mark.parametrize(
+    "config,nrdatafiles,nrsubmodules",
+    [
+        ({}, 5, NR_DEFAULT_SUBMODULES),
+        (
+            {"datafile": [{"3_R001_REEK": ["summary"]}]},
+            1,
+            1,
+        ),
+        (
+            {"datafile": [{"3_R001_REEK": ["summary", "rft"]}]},
+            1,
+            2,
+        ),
+        (
+            {"datafile": ["3_R001_REEK", "OOGRE_PF.in"]},
+            2,
+            NR_DEFAULT_SUBMODULES,
+        ),
+        ({"datafile": ["3_R001_REEK"]}, 1, NR_DEFAULT_SUBMODULES),
+        ({"datafile": ["3_R001_REEK-1.DATA"]}, 1, NR_DEFAULT_SUBMODULES),
+        ({"datafile": ["OOGRE_IX.afi"]}, 1, NR_DEFAULT_SUBMODULES),
+        ({"datafile": ["opm/model/OOGRE_OPM.DATA"]}, 1, NR_DEFAULT_SUBMODULES),
+        ({"datatypes": ["grid"]}, 5, 1),
+    ],
+)
+def test_create_build_sim2sumo_config(
+    config, nrdatafiles, nrsubmodules, tmp_path, monkeypatch
+):
+    real1 = tmp_path / "realization-1/iter-0"
+    copytree(REEK_REAL1, real1)
+    monkeypatch.chdir(real1)
+
+    sim2sumoconfig = _build_sim2sumo_config(config)
+    assert len(sim2sumoconfig) == nrdatafiles, (
+        f"{sim2sumoconfig.keys()} expected to have len {nrdatafiles} datafiles"
+    )
+    for submod, subdict in sim2sumoconfig.items():
+        assert len(subdict) == nrsubmodules, (
+            f"{subdict} for {submod} expected to have {nrsubmodules} submodules"
+        )
+
+
+def test_create_config_returns_sim2sumo_config(scratch_files, monkeypatch):
+    """from_global_variables returns a Sim2SumoConfig with a GlobalConfiguration."""
+    monkeypatch.chdir(scratch_files[0])
+    config = Sim2SumoConfig.from_global_variables(CONFIG_PATH)
+
+    assert isinstance(config, Sim2SumoConfig)
+    assert isinstance(config.global_config, GlobalConfiguration)
+    assert config.global_config.model.name == "ff"
+    assert len(config.sim2sumo) > 0
+
+
+def test_create_config_global_config_has_expected_fields(
+    scratch_files, monkeypatch
+):
+    """GlobalConfiguration loaded via Sim2SumoConfig has masterdata & access."""
+    monkeypatch.chdir(scratch_files[0])
+    config = Sim2SumoConfig.from_global_variables(CONFIG_PATH)
+
+    gc = config.global_config
+    assert gc.masterdata is not None
+    assert gc.access is not None
+    assert gc.access.asset.name == "Drogon"
+    assert gc.model.name == "ff"
+
+
+def test_create_config_with_dot_fmu_global_config_has_expected_fields(
+    ert_run_scratch_files, monkeypatch
+) -> None:
+    """GlobalConfiguration loaded via Sim2SumoConfig has masterdata & access.
+
+    Uses 'ert_run_scratch_files' because it's function scoped."""
+    from fmu.settings._drogon import create_drogon_fmu_dir
+
+    fmu_dir = create_drogon_fmu_dir(ert_run_scratch_files[0])
+    monkeypatch.chdir(ert_run_scratch_files[0])
+
+    fmu_dir_config = fmu_dir.config.load()
+    config = Sim2SumoConfig.from_global_variables(CONFIG_PATH)
+    global_config = config.global_config
+
+    assert fmu_dir_config.masterdata == global_config.masterdata
+    assert fmu_dir_config.model == global_config.model
+    assert global_config.model.name == "Drogon"  # .fmu/ not set as 'ff'
+
+
+def test_create_config_sim2sumo_options_match_yaml(scratch_files, monkeypatch):
+    """The sim2sumo options extracted by Sim2SumoConfig match what's in the YAML."""
+    monkeypatch.chdir(scratch_files[0])
+    config = Sim2SumoConfig.from_global_variables(CONFIG_PATH)
+
+    for _datafile, submods in config.sim2sumo.items():
+        assert set(submods.keys()) == {"summary", "rft", "satfunc", "grid"}
+        assert submods["grid"]["rstprops"] == DEFAULT_RST_PROPS
+
+
+def test_create_config_global_config_passed_to_exportdata(
+    scratch_files, monkeypatch
+):
+    """GlobalConfiguration is accepted by ExportData without error."""
+    monkeypatch.chdir(scratch_files[0])
+    config = Sim2SumoConfig.from_global_variables(CONFIG_PATH)
+
+    exd = ExportData(
+        config=config.global_config,
+        name="test",
+        tagname="test",
+        content="depth",
+    )
+    assert exd._export_config.config == config.global_config

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,14 +2,13 @@
 
 import os
 from io import BytesIO
-from shutil import copytree
 from time import sleep
 
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from conftest import REEK_DATA_FILE, REEK_REAL0, REEK_REAL1
+from conftest import CONFIG_PATH, REEK_DATA_FILE, REEK_REAL0, REEK_REAL1
 from fmu.sumo.uploader import SumoConnection
 from numpy.ma import allclose, allequal
 from xtgeo import GridProperty, gridproperty_from_file
@@ -17,7 +16,6 @@ from xtgeo import GridProperty, gridproperty_from_file
 from fmu.sumo.sim2sumo import grid3d, tables
 from fmu.sumo.sim2sumo._special_treatments import (
     DEFAULT_RST_PROPS,
-    DEFAULT_SUBMODULES,
     SUBMODULES,
     _define_submodules,
     convert_to_arrow,
@@ -28,7 +26,6 @@ from fmu.sumo.sim2sumo._units import (
 )
 from fmu.sumo.sim2sumo.common import (
     Dispatcher,
-    create_config_dict,
     find_datafiles,
     find_datefield,
     get_case_uuid,
@@ -100,52 +97,6 @@ def test_get_case_uuid(case_uuid, scratch_files, monkeypatch):
     assert uuid == case_uuid
 
 
-NR_DEFAULT_SUBMODULES = len(DEFAULT_SUBMODULES)
-
-
-@pytest.mark.parametrize(
-    "config,nrdatafiles,nrsubmodules",
-    [
-        ({}, 5, NR_DEFAULT_SUBMODULES),
-        (
-            {"datafile": [{"3_R001_REEK": ["summary"]}]},
-            1,
-            1,
-        ),
-        (
-            {"datafile": [{"3_R001_REEK": ["summary", "rft"]}]},
-            1,
-            2,
-        ),
-        (
-            {"datafile": ["3_R001_REEK", "OOGRE_PF.in"]},
-            2,
-            NR_DEFAULT_SUBMODULES,
-        ),
-        ({"datafile": ["3_R001_REEK"]}, 1, NR_DEFAULT_SUBMODULES),
-        ({"datafile": ["3_R001_REEK-1.DATA"]}, 1, NR_DEFAULT_SUBMODULES),
-        ({"datafile": ["OOGRE_IX.afi"]}, 1, NR_DEFAULT_SUBMODULES),
-        ({"datafile": ["opm/model/OOGRE_OPM.DATA"]}, 1, NR_DEFAULT_SUBMODULES),
-        ({"datatypes": ["grid"]}, 5, 1),
-    ],
-)
-def test_create_config_dict(config, nrdatafiles, nrsubmodules, tmp_path):
-    real1 = tmp_path / "realone"
-    copytree(REEK_REAL1, real1)
-    os.chdir(real1)
-    sim2sumo_config = {"sim2sumo": config}
-    inputs = create_config_dict(sim2sumo_config)
-    sim2sumoconfig = inputs["sim2sumoconfig"]
-    assert len(inputs.keys()) == 2
-    assert len(sim2sumoconfig) == nrdatafiles, (
-        f"{sim2sumoconfig.keys()} expected to have len {nrdatafiles} datafiles"
-    )
-    for submod, subdict in sim2sumoconfig.items():
-        assert len(subdict) == nrsubmodules, (
-            f"{subdict} for {submod} expected to have {nrsubmodules} submodules"
-        )
-
-
 def test_Dispatcher(case_uuid, token, scratch_files, monkeypatch):
     disp = Dispatcher(scratch_files[2], "dev", token=token)
     monkeypatch.chdir(scratch_files[0])
@@ -187,7 +138,7 @@ def test_convert_xtgeo_to_sumo_file(
     )
     file = grid3d.convert_xtgeo_to_sumo_file(eightfipnum, metadata)
     sumo_conn = SumoConnection(env="dev", token=token)
-    nodisk_upload([file], case_uuid, "dev", connection=sumo_conn)
+    nodisk_upload([file], case_uuid, CONFIG_PATH, connection=sumo_conn)
     sleep(SLEEP_TIME)
     obj = get_sumo_object(sumo, case_uuid, "FIPNUM", "EIGHTCELLS")
     prop = gridproperty_from_file(obj)
@@ -208,7 +159,7 @@ def test_convert_table_2_sumo_file(
     )[0]
 
     sumo_conn = SumoConnection(env="dev", token=token)
-    nodisk_upload([file], case_uuid, "dev", connection=sumo_conn)
+    nodisk_upload([file], case_uuid, CONFIG_PATH, connection=sumo_conn)
     sleep(SLEEP_TIME)
     obj = get_sumo_object(sumo, case_uuid, "EIGHTCELLS", "rft")
     table = pq.read_table(obj)
@@ -312,7 +263,7 @@ def test_get_all_restart_properties(scratch_files, xtgeogrid):
 def test_get_restart_properties(scratch_files, xtgeogrid, s2s_config):
     restart_path = str(scratch_files[1]).replace(".DATA", ".UNRST")
     prop_names = grid3d.get_restart_properties(
-        restart_path, xtgeogrid, s2s_config["sim2sumoconfig"][scratch_files[1]]
+        restart_path, xtgeogrid, s2s_config.sim2sumo[scratch_files[1]]
     )
 
     # Testing using default restart properties

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -138,7 +138,9 @@ def test_convert_xtgeo_to_sumo_file(
     )
     file = grid3d.convert_xtgeo_to_sumo_file(eightfipnum, metadata)
     sumo_conn = SumoConnection(env="dev", token=token)
-    nodisk_upload([file], case_uuid, CONFIG_PATH, connection=sumo_conn)
+    nodisk_upload(
+        [file], case_uuid, CONFIG_PATH, env="dev", connection=sumo_conn
+    )
     sleep(SLEEP_TIME)
     obj = get_sumo_object(sumo, case_uuid, "FIPNUM", "EIGHTCELLS")
     prop = gridproperty_from_file(obj)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -161,7 +161,9 @@ def test_convert_table_2_sumo_file(
     )[0]
 
     sumo_conn = SumoConnection(env="dev", token=token)
-    nodisk_upload([file], case_uuid, CONFIG_PATH, connection=sumo_conn)
+    nodisk_upload(
+        [file], case_uuid, CONFIG_PATH, env="dev", connection=sumo_conn
+    )
     sleep(SLEEP_TIME)
     obj = get_sumo_object(sumo, case_uuid, "EIGHTCELLS", "rft")
     table = pq.read_table(obj)

--- a/tests/test_standard_results.py
+++ b/tests/test_standard_results.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-import yaml
 from fmu.dataio._definitions import STANDARD_TABLE_INDEX_COLUMNS
 from fmu.datamodels.fmu_results.enums import Content
 from fmu.datamodels.standard_results import StandardResultName
 
 from fmu.sumo.sim2sumo import __version__
+from fmu.sumo.sim2sumo.config import Sim2SumoConfig
 from fmu.sumo.sim2sumo.tables import SUBMOD_CONTENT, generate_table_meta
 
 
@@ -19,11 +19,7 @@ def test_table_standard_result_metadata(
     tagname: str,
 ) -> None:
     realization, datafile, config_path, grid = scratch_files
-
-    with open(config_path) as f:
-        global_config_dict = yaml.safe_load(f)
-
-    config_dict = {"fmuconfig": global_config_dict}
+    config = Sim2SumoConfig.from_global_variables(config_path)
 
     content_str = SUBMOD_CONTENT.get(tagname)
     content_enum = Content(content_str)
@@ -36,7 +32,7 @@ def test_table_standard_result_metadata(
 
     table = pd.DataFrame({col: [1, 2, 3] for col in std_columns.columns})
 
-    metadata = generate_table_meta(datafile, table, tagname, config_dict)
+    metadata = generate_table_meta(datafile, table, tagname, config)
     assert metadata["data"]["standard_result"] is not None
     assert (
         metadata["data"]["standard_result"]["name"]


### PR DESCRIPTION
Resolves https://github.com/equinor/fmu-dataio/issues/1674

Introduces a `Sim2SumoConfig` dataclass and `config` module to act as a container for configuration elements. This allows the global configuration, previously a dictionary, to be loaded from a .fmu/ directory if one exists. The object returned, in either case, will be a `GlobalConfiguration` Pydantic class as defined from fmu-datamodels.