### PR TITLE
feat: upload all vfp tables in one table with human-readable headers

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -30,7 +30,7 @@ Default data types
    * grid (INIT "initial" and restart "dynamic" 3D grid properties)
    * pvt (PVT tables)
    * trans (transmissibilities)
-   * vfp (lift curves; one table for each lift curve)
+   * vfp (lift curves; one table for all lift curves)
 
    See `Configuration of sim2sumo`_.
 

--- a/src/fmu/sumo/sim2sumo/_special_treatments.py
+++ b/src/fmu/sumo/sim2sumo/_special_treatments.py
@@ -61,10 +61,10 @@ def find_arrow_convertor(path):
 
 def _extract_vfp_df(deck: res2df.ResdataFiles, **kwargs) -> pd.DataFrame:
     """
-    res2df has different behaviour for vfp, so this wrapper is used to have
-    similar behaviour to the other res2df.submod.df methods. Extracts VFP
-    dataframes for both VFPPROD and VFPINJ (if present) and combine into one
-    dataframe.
+    res2df has different behaviour for vfp. This wrapper is used so that vfp
+    data extraction has similar behaviour to the other res2df.submod.df methods.
+    Extracts VFP dataframes for both VFPPROD and VFPINJ (if present) and combines
+    them into one dataframe.
 
     Args:
         deck (res2df.ResdataFiles): class containing link to the simulator datafile

--- a/src/fmu/sumo/sim2sumo/_special_treatments.py
+++ b/src/fmu/sumo/sim2sumo/_special_treatments.py
@@ -69,7 +69,11 @@ def find_functions_and_docstring(submod):
         dictionary: includes functions and doc string
     """
     import_path = "res2df." + submod
-    func = importlib.import_module(import_path).df
+    if submod == "vfp":
+        # Load all vfp tables into one dataframe using .dfs
+        func = importlib.import_module(import_path).dfs
+    else:
+        func = importlib.import_module(import_path).df
     returns = {
         "extract": func,
         "options": tuple(
@@ -141,27 +145,3 @@ DEFAULT_SUBMODULES = [
     "wellcompletiondata",
 ]
 DEFAULT_RST_PROPS = ["SGAS", "SOIL", "SWAT", "PRESSURE"]
-
-
-def vfp_to_arrow_dict(datafile, options):
-    """Generate dictionary with vfp arrow tables
-
-    Args:
-        datafile (str): The datafile to extract from
-        options (dict): options for extraction
-
-    Returns:
-        tuple: vfp keyword, then dictionary with key: table_name, value: table
-    """
-    filepath_no_suffix = Path(datafile).with_suffix("")
-    resdatafiles = res2df.ResdataFiles(filepath_no_suffix)
-    vfp_dict = {}
-    keyword = options.get("keyword", ["VFPPROD", "VFPINJ"])
-    vfpnumbers = options.get("vfpnumbers", None)
-    keywords = [keyword] if isinstance(keyword, str) else keyword
-
-    for keyword in keywords:
-        vfp_dict[keyword] = res2df.vfp._vfp.pyarrow_tables(
-            resdatafiles.get_deck(), keyword=keyword, vfpnumbers_str=vfpnumbers
-        )
-    return vfp_dict

--- a/src/fmu/sumo/sim2sumo/_special_treatments.py
+++ b/src/fmu/sumo/sim2sumo/_special_treatments.py
@@ -59,7 +59,7 @@ def find_arrow_convertor(path):
     return func
 
 
-def _extract_vfp_df(rdf: res2df.ResdataFiles, **kwargs) -> pd.DataFrame:
+def _extract_vfp_df(deck: res2df.ResdataFiles, **kwargs) -> pd.DataFrame:
     """
     res2df has different behaviour for vfp, so this wrapper is used to have
     similar behaviour to the other res2df.submod.df methods. Extracts VFP
@@ -67,13 +67,13 @@ def _extract_vfp_df(rdf: res2df.ResdataFiles, **kwargs) -> pd.DataFrame:
     dataframe.
 
     Args:
-        datafile_path (str): the path to the simulator datafile
+        deck (res2df.ResdataFiles): class containing link to the simulator datafile
 
     Returns:
         pd.DataFrame: dataframe with both VFPPROD and VFPINJ data.
     """
-    df_vfpprod = res2df.vfp._vfp.df(rdf, "VFPPROD")
-    df_vfpinj = res2df.vfp._vfp.df(rdf, "VFPINJ")
+    df_vfpprod = res2df.vfp._vfp.df(deck, "VFPPROD")
+    df_vfpinj = res2df.vfp._vfp.df(deck, "VFPINJ")
     df = pd.concat((df_vfpprod, df_vfpinj))
 
     return df

--- a/src/fmu/sumo/sim2sumo/_special_treatments.py
+++ b/src/fmu/sumo/sim2sumo/_special_treatments.py
@@ -59,6 +59,26 @@ def find_arrow_convertor(path):
     return func
 
 
+def _extract_vfp_df(rdf: res2df.ResdataFiles, **kwargs) -> pd.DataFrame:
+    """
+    res2df has different behaviour for vfp, so this wrapper is used to have
+    similar behaviour to the other res2df.submod.df methods. Extracts VFP
+    dataframes for both VFPPROD and VFPINJ (if present) and combine into one
+    dataframe.
+
+    Args:
+        datafile_path (str): the path to the simulator datafile
+
+    Returns:
+        pd.DataFrame: dataframe with both VFPPROD and VFPINJ data.
+    """
+    df_vfpprod = res2df.vfp._vfp.df(rdf, "VFPPROD")
+    df_vfpinj = res2df.vfp._vfp.df(rdf, "VFPINJ")
+    df = pd.concat((df_vfpprod, df_vfpinj))
+
+    return df
+
+
 def find_functions_and_docstring(submod):
     """Find functions for extracting and converting from eclipse native
 
@@ -69,9 +89,9 @@ def find_functions_and_docstring(submod):
         dictionary: includes functions and doc string
     """
     import_path = "res2df." + submod
-    if submod == "vfp":
-        # Load all vfp tables into one dataframe using .dfs
-        func = importlib.import_module(import_path).dfs
+    if submod == "vfp._vfp":
+        # Load all vfp tables into one dataframe using wrapper function
+        func = _extract_vfp_df
     else:
         func = importlib.import_module(import_path).df
     returns = {

--- a/src/fmu/sumo/sim2sumo/tables.py
+++ b/src/fmu/sumo/sim2sumo/tables.py
@@ -197,6 +197,24 @@ def convert_table_2_sumo_file(datafile, obj, tagname, config):
     return files
 
 
+def _extract_vfp_df(datafile_path: str, **kwargs) -> pd.DataFrame:
+    """
+    Extract VFP dataframes for both VFPPROD and VFPINJ (if present) and combine into one dataframe.
+
+    Args:
+        datafile_path (str): the path to the simulator datafile
+
+    Returns:
+        pd.DataFrame: dataframe with both VFPPROD and VFPINJ data.
+    """
+    rdf = res2df.ResdataFiles(datafile_path)
+    df_vfpprod = res2df.vfp._vfp.df(rdf, "VFPPROD")
+    df_vfpinj = res2df.vfp._vfp.df(rdf, "VFPINJ")
+    df = pd.concat((df_vfpprod, df_vfpinj))
+
+    return df
+
+
 def get_table(
     datafile_path: str, submod: str, **kwargs
 ) -> Union[pa.Table, pd.DataFrame, None]:
@@ -225,10 +243,14 @@ def get_table(
             submod,
         )
 
-        output = extract_df(
-            res2df.ResdataFiles(datafile_path),
-            **kwargs,
-        )
+        if submod == "vfp":
+            output = _extract_vfp_df(datafile_path, **kwargs)
+
+        else:
+            output = extract_df(
+                res2df.ResdataFiles(datafile_path),
+                **kwargs,
+            )
 
         if submod == "rft":
             output = delete_unwanted_rft_files(output)

--- a/src/fmu/sumo/sim2sumo/tables.py
+++ b/src/fmu/sumo/sim2sumo/tables.py
@@ -197,9 +197,12 @@ def convert_table_2_sumo_file(datafile, obj, tagname, config):
     return files
 
 
-def _extract_vfp_df(datafile_path: str, **kwargs) -> pd.DataFrame:
+def _extract_vfp_df(rdf: res2df.ResdataFiles, **kwargs) -> pd.DataFrame:
     """
-    Extract VFP dataframes for both VFPPROD and VFPINJ (if present) and combine into one dataframe.
+    res2df has different behaviour for vfp, so this wrapper is used to have
+    similar behaviour to the other res2df.submod.df methods. Extracts VFP
+    dataframes for both VFPPROD and VFPINJ (if present) and combine into one
+    dataframe.
 
     Args:
         datafile_path (str): the path to the simulator datafile
@@ -207,7 +210,6 @@ def _extract_vfp_df(datafile_path: str, **kwargs) -> pd.DataFrame:
     Returns:
         pd.DataFrame: dataframe with both VFPPROD and VFPINJ data.
     """
-    rdf = res2df.ResdataFiles(datafile_path)
     df_vfpprod = res2df.vfp._vfp.df(rdf, "VFPPROD")
     df_vfpinj = res2df.vfp._vfp.df(rdf, "VFPINJ")
     df = pd.concat((df_vfpprod, df_vfpinj))
@@ -228,13 +230,21 @@ def get_table(
     Returns:
         pd.DataFrame: the extracted data
     """
+
     logger = logging.getLogger(__file__ + ".get_table")
-    extract_df = SUBMOD_DICT[submod]["extract"]
+
+    if submod == "vfp":
+        extract_df = _extract_vfp_df
+
+    else:
+        extract_df = SUBMOD_DICT[submod]["extract"]
+
     arrow = kwargs.get("arrow", True)
 
     with contextlib.suppress(KeyError):
         del kwargs["arrow"]
     output = None
+
     try:
         logger.info(
             "Extracting data from %s with func %s for %s",
@@ -243,14 +253,10 @@ def get_table(
             submod,
         )
 
-        if submod == "vfp":
-            output = _extract_vfp_df(datafile_path, **kwargs)
-
-        else:
-            output = extract_df(
-                res2df.ResdataFiles(datafile_path),
-                **kwargs,
-            )
+        output = extract_df(
+            res2df.ResdataFiles(datafile_path),
+            **kwargs,
+        )
 
         if submod == "rft":
             output = delete_unwanted_rft_files(output)

--- a/src/fmu/sumo/sim2sumo/tables.py
+++ b/src/fmu/sumo/sim2sumo/tables.py
@@ -197,26 +197,6 @@ def convert_table_2_sumo_file(datafile, obj, tagname, config):
     return files
 
 
-def _extract_vfp_df(rdf: res2df.ResdataFiles, **kwargs) -> pd.DataFrame:
-    """
-    res2df has different behaviour for vfp, so this wrapper is used to have
-    similar behaviour to the other res2df.submod.df methods. Extracts VFP
-    dataframes for both VFPPROD and VFPINJ (if present) and combine into one
-    dataframe.
-
-    Args:
-        datafile_path (str): the path to the simulator datafile
-
-    Returns:
-        pd.DataFrame: dataframe with both VFPPROD and VFPINJ data.
-    """
-    df_vfpprod = res2df.vfp._vfp.df(rdf, "VFPPROD")
-    df_vfpinj = res2df.vfp._vfp.df(rdf, "VFPINJ")
-    df = pd.concat((df_vfpprod, df_vfpinj))
-
-    return df
-
-
 def get_table(
     datafile_path: str, submod: str, **kwargs
 ) -> Union[pa.Table, pd.DataFrame, None]:
@@ -232,13 +212,7 @@ def get_table(
     """
 
     logger = logging.getLogger(__file__ + ".get_table")
-
-    if submod == "vfp":
-        extract_df = _extract_vfp_df
-
-    else:
-        extract_df = SUBMOD_DICT[submod]["extract"]
-
+    extract_df = SUBMOD_DICT[submod]["extract"]
     arrow = kwargs.get("arrow", True)
 
     with contextlib.suppress(KeyError):

--- a/src/fmu/sumo/sim2sumo/tables.py
+++ b/src/fmu/sumo/sim2sumo/tables.py
@@ -29,7 +29,6 @@ from ._special_treatments import (
     SUBMOD_DICT,
     convert_to_arrow,
     delete_unwanted_rft_files,
-    vfp_to_arrow_dict,
 )
 from .common import find_datefield, give_name
 from .version import version
@@ -274,31 +273,6 @@ def upload_tables(config, dispatcher):
         )
 
 
-def upload_vfp_tables_from_simulation_run(
-    datafile, options, config, dispatcher
-):
-    """Upload vfp tables from one simulator run to Sumo
-
-    Args:
-        datafile (str): the datafile defining the simulation run
-        options (dict): the options for vfp
-        config (dict): the fmuconfig with metadata and sim2sumoconfig
-        dispatcher (sim2sumo.common.Dispatcher): job dispatcher
-    """
-    vfp_dict = vfp_to_arrow_dict(datafile, options)
-    for keyword, tables in vfp_dict.items():
-        for table in tables:
-            table_number = str(
-                table.schema.metadata[b"TABLE_NUMBER"].decode("utf-8")
-            )
-            tagname = f"{keyword}_{table_number}"
-            sumo_files = convert_table_2_sumo_file(
-                datafile, table, tagname.lower(), config
-            )
-            for file in sumo_files:
-                dispatcher.add(file)
-
-
 def upload_tables_from_simulation_run(
     datafile, submod_and_options, config, dispatcher
 ):
@@ -316,10 +290,6 @@ def upload_tables_from_simulation_run(
             # No tables for grid3d
             continue
 
-        if submod == "vfp":
-            upload_vfp_tables_from_simulation_run(
-                datafile, options, config, dispatcher
-            )
         else:
             table = get_table(datafile, submod, **options)
 

--- a/tests/test_w_drogon.py
+++ b/tests/test_w_drogon.py
@@ -1,12 +1,11 @@
+from enum import unique
 from pathlib import Path
 
+import pyarrow.compute as pc
 import pytest
-from test_functions import check_sumo
 
-from fmu.sumo.sim2sumo._special_treatments import vfp_to_arrow_dict
-from fmu.sumo.sim2sumo.common import Dispatcher
 from fmu.sumo.sim2sumo.tables import (
-    upload_vfp_tables_from_simulation_run,
+    get_table,
 )
 
 DROGON = Path(__file__).parent / "data/drogon/"
@@ -14,38 +13,19 @@ DROGON_REAL = DROGON / "realization-0/iter-0/"
 DROGON_DATAFILE = DROGON_REAL / "eclipse/model/DROGON-0.DATA"
 
 
-@pytest.mark.parametrize(
-    "options,keycombo,nrkeys,nrtables",
-    [
-        ({}, ["VFPPROD", "VFPINJ"], 2, 5),
-        ({"keyword": "VFPINJ"}, ["VFPINJ"], 1, 1),
-        ({"keyword": ["VFPPROD", "VFPINJ"]}, ["VFPPROD", "VFPINJ"], 2, 5),
-        ({"vfpnumbers": "1,2,4"}, ["VFPPROD", "VFPINJ"], 2, 3),
-    ],
-)
-def test_vfp_to_arrow(options, keycombo, nrkeys, nrtables):
-    arrow_dict = vfp_to_arrow_dict(DROGON_DATAFILE, options)
-    assert len(arrow_dict) == nrkeys
-    nr_tables = 0
-    for value in arrow_dict.values():
-        nr_tables += len(value)
+def test_get_table_vfp():
+    table = get_table(str(DROGON_DATAFILE), "vfp")
 
-    assert nr_tables == nrtables, (
-        f"Returned {nr_tables} tables, but should be {nrtables}"
+    unique_vfp_type = pc.unique(table["VFP_TYPE"])  # VFP_PROD & VFP_INJ
+    unique_table_number = pc.unique(
+        table["TABLE_NUMBER"]
+    )  # 1, 2, 3, 4 (all VFP_PROD) & 13 (VFP_INJ)
+
+    print(unique_vfp_type, unique_table_number)
+
+    assert len(unique_vfp_type) == 2, (
+        f"Returned {len(unique_vfp_type)} ({unique_vfp_type}), but should be 2."
     )
-    assert set(arrow_dict.keys()) == set(keycombo), (
-        f"Returned keys {arrow_dict.keys()}, should be {keycombo}"
+    assert len(unique_table_number) == 5, (
+        f"Returned {len(unique_table_number)} ({unique_table_number}), but should be 5."
     )
-
-
-def test_vfp_tables_from_simulation_run(
-    scratch_files, s2s_config, sumo, case_uuid, monkeypatch
-):
-    monkeypatch.chdir(scratch_files[0])
-    disp = Dispatcher(scratch_files[2], "dev")
-
-    upload_vfp_tables_from_simulation_run(
-        DROGON_DATAFILE, {}, s2s_config, disp
-    )
-    disp.finish()
-    check_sumo(case_uuid, "table", 5, sumo)

--- a/tests/test_w_drogon.py
+++ b/tests/test_w_drogon.py
@@ -21,8 +21,6 @@ def test_get_table_vfp():
         table["TABLE_NUMBER"]
     )  # 1, 2, 3, 4 (all VFP_PROD) & 13 (VFP_INJ)
 
-    print(unique_vfp_type, unique_table_number)
-
     assert len(unique_vfp_type) == 2, (
         f"Returned {len(unique_vfp_type)} ({unique_vfp_type}), but should be 2."
     )

--- a/tests/test_w_drogon.py
+++ b/tests/test_w_drogon.py
@@ -1,8 +1,6 @@
-from enum import unique
 from pathlib import Path
 
 import pyarrow.compute as pc
-import pytest
 
 from fmu.sumo.sim2sumo.tables import (
     get_table,


### PR DESCRIPTION
 ## Issue
#210 

## Description
Using a wrapper function to create a single dataframe with all lift curves, and including both production and injection lift curves.

## How to test
Run Drogon -> check results in Sumo frontend. There's now one lift curve table per realisation, with human-readable headers. Note that there are no injection lift curves in the Drogon model, but this scenario is tested with pytest. 

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [x] Documentation has been updated 🧾
- [x] Commits are semantic ✅