### PR TITLE
feat: add sim2sumo version to _sumo

### DIFF
--- a/src/fmu/sumo/sim2sumo/tables.py
+++ b/src/fmu/sumo/sim2sumo/tables.py
@@ -192,6 +192,7 @@ def convert_table_2_sumo_file(
             _sumo["blob_md5"] = md5_b64
             _sumo["hidden"] = True
             _sumo["fragment"] = idx
+            _sumo["sim2sumo"] = version
 
             files.append(sumo_file)
 
@@ -200,6 +201,7 @@ def convert_table_2_sumo_file(
     sumo_file.path = metadata["file"]["relative_path"]
     sumo_file.metadata_path = ""
     sumo_file.size = len(sumo_file.byte_string)
+    sumo_file.metadata.setdefault("_sumo", {})["sim2sumo"] = version
     files.append(sumo_file)
 
     return files


### PR DESCRIPTION
 ## Issue
https://github.com/equinor/fmu-sumo-uploader/issues/210https://github.com/equinor/fmu-sumo-uploader/issues/210

## Description
Add a field `_sumo.sim2sumo` for objects uploaded by sim2sumo

## How to test
Verify in preview

Go to this case and check metadata of the summary file.
https://main-sumo-ui-preview.c3.radix.equinor.com/caselist/?filters=%7B%22_id%22%3A%5B%2218e3984d-ee35-4fdf-b2b2-43a45215007d%22%5D%7D&asset=Drogon

## Checklist
- [ ] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [ ] New/refactored code is following same conventions as the rest of the code base 🧬
- [ ] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [ ] Commits are semantic ✅