### PR TITLE
fix: remove sumo_login check at startup

### DIFF
--- a/src/fmu/sumo/sim2sumo/forward_models/__init__.py
+++ b/src/fmu/sumo/sim2sumo/forward_models/__init__.py
@@ -40,16 +40,6 @@ class Sim2Sumo(ForwardModelStepPlugin):
             raise ForwardModelStepValidationError(
                 f"Invalid value for environment variable 'SUMO_ENV': {env}. Valid values are preview, dev, test and prod."
             )
-        command = f"sumo_login -e {env} -m silent"
-        return_code = subprocess.call(command, shell=True)
-
-        err_msg = (
-            "Your access token for Sumo is either missing or expired. "
-            "Please run 'sumo_login' in a terminal window to log in again."
-        )
-
-        if return_code != 0:
-            raise ForwardModelStepValidationError(err_msg)
 
     @staticmethod
     def documentation() -> ForwardModelStepDocumentation | None:


### PR DESCRIPTION
 ## Issue
Closes #222 

## Description
Similar to change in uploader: https://github.com/equinor/fmu-sumo-uploader/pull/200


## How to test
- Delete tokens from ~/.sumo
- Start ERT with a model that has Sim2sumo enabled
- Verify that ERT starts without warning that no Sumo token was found

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅