### PR TITLE
Fresh connection per upload batch

### DIFF
--- a/src/fmu/sumo/sim2sumo/common.py
+++ b/src/fmu/sumo/sim2sumo/common.py
@@ -132,12 +132,9 @@ class Dispatcher:
         self._logger = logging.getLogger(__name__ + ".Dispatcher")
         self._limit_percent = 0.5
         self._parentid = get_case_uuid(datafile.resolve())
-        self._conn = SumoClient(
-            env=env,
-            token=token,
-            case_uuid=self._parentid,
-            client_id=uploader_client_id,
-        )
+        self._env = env
+        self._token = token
+        self._conn = self._create_connection()
         self._mem_limit = (
             psutil.virtual_memory().available * self._limit_percent
         )
@@ -148,6 +145,14 @@ class Dispatcher:
         self._objects = []
         self._logger.info(
             "Init, parent is %s, and env is %s", self.parentid, env
+        )
+
+    def _create_connection(self) -> SumoClient:
+        return SumoClient(
+            env=self._env,
+            token=self._token,
+            case_uuid=self._parentid,
+            client_id=uploader_client_id,
         )
 
     @property
@@ -190,6 +195,11 @@ class Dispatcher:
 
     def _upload(self):
         self._logger.debug("%s files to upload", len(self._objects))
+
+        # Use a fresh connection for every upload batch, otherwise
+        # we get an "Event loop is closed" error since asyncio.run()
+        # is called per batch, closing the event loop.
+        self._conn = self._create_connection()
         nodisk_upload(
             self._objects,
             self._parentid,
@@ -198,6 +208,7 @@ class Dispatcher:
         )
         self._objects = []
         self._mem_count = 0
+        self._count = 0
 
     def finish(self):
         """Cleanup"""


### PR DESCRIPTION
* `self._count` is not reset in `_upload()`, i.e. after 100 objects, every subsequent `add()` appears to trigger an individual upload.
* Sumo connection is reused across upload batches. The [`sumo-upload` `upload_files()` calls `asyncio.run()`](https://github.com/equinor/fmu-sumo-uploader/blob/03e230e9b6a86f993247433f34695e5a1e46300a/src/fmu/sumo/uploader/_upload_files.py#L231) (which closes the event loop, and subsequent usage of the same connection gives error "Event loop is closed").

The `SIM2SUMO` `grid` `rptrst` combination amplified this issue, since it typically always produces `>> 100` properties.