### PR TITLE
fix: get httpx response status_code correctly

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -74,7 +74,7 @@ def check_sumo(case_uuid, class_type, expected_count, sumo):
         delete_res = sumo.delete(f"/objects('{object_id}')")
         try:
             res = sumo.poll(delete_res)
-            assert res.status == 200, (
+            assert res.status_code == 200, (
                 f"Failed to delete object {object_id} when cleaning up test"
             )
         except httpx.HTTPStatusError as err:


### PR DESCRIPTION
 ## Issue
Fixes failing tests: https://github.com/equinor/fmu-sumo-sim2sumo/actions/runs/30518224330/job/90792714864

## Description
Correct method to get `httpx` status code is `.status_code` not `.status`

## How to test
Tests pass

## Checklist
- [x] No redundant \`print()\` statements, commented-out code, or other remnants from the development 👀
- [x] New/refactored code is following same conventions as the rest of the code base 🧬
- [x] New/refactored code is tested ⚙
- [ ] Documentation has been updated 🧾
- [x] Commits are semantic ✅